### PR TITLE
(maint) Fix bash syntax around disabling coveralls

### DIFF
--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -42,9 +42,9 @@ function travis_make()
             exit 1
         fi
 
-        if [ $1 == "debug" ]; then
+        #if [ $1 == "debug" ]; then
             #coveralls --gcov-options '\-lp' -r .. >/dev/null
-        fi
+        #fi
     fi
 }
 


### PR DESCRIPTION
Coveralls was commented out until CFLAGS setting between
cfacter/leatherman can be cleaned up. Unfortunately bash is terrible.