### PR TITLE
(maint) Restore comment about UNICODE on Windows

### DIFF
--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -59,6 +59,7 @@ if (WIN32)
 
     # The GetUserNameEx function requires the application have a defined security level.
     # We define security sufficient to get the current user's info.
+    # Also force use of UNICODE APIs, following the pattern outlined at http://utf8everywhere.org/.
     set(LEATHERMAN_DEFINITIONS -DUNICODE -D_UNICODE -DSECURITY_WIN32)
 else()
     set(LEATHERMAN_DEFINITIONS -DUSE_POSIX_FUNCTIONS)


### PR DESCRIPTION
We force use of Unicode on Windows, following the pattern defined at
http://utf8everywhere.org/. Keep the comment from cfacter pointing out
that we're making that choice.