### PR TITLE
(CFACT-235) Clean up handling of defoptions for use by containing projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,6 @@ project(LEATHERMAN)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)
-include(leatherman)
-include(cflags)
-
-add_definitions(${LEATHERMAN_DEFINITIONS})
 
 # If we're the top-level project, we want to ensure the build type is
 # sane, and flag ourselves as such for later checks
@@ -25,6 +21,15 @@ endif()
 defoption(LEATHERMAN_DEFAULT_ENABLE "Should Leatherman libraries all be built by default" ${LEATHERMAN_TOPLEVEL})
 defoption(LEATHERMAN_DEBUG "Enable verbose logging messages from leatherman macros" FALSE)
 defoption(LEATHERMAN_ENABLE_TESTING "Build the leatherman test binary" ${LEATHERMAN_DEFAULT_ENABLE})
+
+#As with most things, we rely on the containing project to set up the
+#common flags
+if (LEATHERMAN_TOPLEVEL)
+    include(options)
+    include(cflags)
+endif()
+
+add_definitions(${LEATHERMAN_DEFINITIONS})
 
 add_leatherman_dir(catch EXCLUDE_FROM_VARS)
 add_leatherman_dir(nowide)

--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -1,7 +1,3 @@
-include(leatherman)
-defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
-defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
-
 # Set compiler-specific flags
 # Each of our project dirs sets CMAKE_CXX_FLAGS based on these. We do
 # not set CMAKE_CXX_FLAGS globally because gtest is not warning-clean.
@@ -67,11 +63,7 @@ endif()
 
 list(APPEND LEATHERMAN_DEFINITIONS -DBOOST_LOG_WITHOUT_WCHAR_T)
 
-# Find our dependency packages
-if (BOOST_STATIC)
-    set(Boost_USE_STATIC_LIBS ON)
-else()
+if (NOT BOOST_STATIC)
     # Boost.Log requires that BOOST_LOG_DYN_LINK is set when using dynamic linking. We set ALL for consistency.
     list(APPEND LEATHERMAN_DEFINITIONS -DBOOST_ALL_DYN_LINK)
-    set(Boost_USE_STATIC_LIBS OFF)
 endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,0 +1,6 @@
+include(leatherman)
+defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
+defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
+
+# Map our boost option to the for-realsies one
+set(Boost_USE_STATIC_LIBS ${BOOST_STATIC})


### PR DESCRIPTION
The defoptions that were intended to be shared with containing
projects had been tossed at the top of `cflags.cmake`. It turns out we
really want to think about these as separate things, so they've been
split out.

Also now we only pull in cflags and options if we're top-level. When
leatherman is embedded we want to rely on the calling project to deal
with this stuff.