### PR TITLE
(CFACT-265) Disable global locale setting

### DIFF
--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -1,14 +1,13 @@
 if(WIN32)
     set(LEATHERMAN_LOCALE_SRCS "src/windows/locale.cc")
-    set(PLATFORM_COMPONENTS locale)
+    find_package(Boost 1.54 REQUIRED COMPONENTS locale)
 else()
     set(LEATHERMAN_LOCALE_SRCS "src/posix/locale.cc")
+    find_package(Boost 1.54 REQUIRED)
 endif()
 
-find_package(Boost 1.54 REQUIRED COMPONENTS system filesystem thread ${PLATFORM_COMPONENTS})
 
 add_leatherman_includes(${Boost_INCLUDE_DIRS})
-add_leatherman_deps("${Boost_THREAD_LIBRARY}" "${Boost_SYSTEM_LIBRARY}" "${Boost_FILESYSTEM_LIBRARY}")
 if (WIN32)
     add_leatherman_deps("${Boost_LOCALE_LIBRARY}")
 endif()

--- a/locale/inc/leatherman/locale/locale.hpp
+++ b/locale/inc/leatherman/locale/locale.hpp
@@ -3,13 +3,14 @@
 * Declares utility functions for setting the locale.
 */
 #pragma once
+#include <locale>
 
 namespace leatherman { namespace locale {
 
     /**
-     * Sets the locale to the specified locale id and imbues it in boost::filesystem.
-     * @param id The locale ID, defaults to the system default.
+     * Gets a locale object for the specified locale id.
+     * @param id The locale ID, defaults to a UTF-8 compatible system default.
      */
-    void set_locale(std::string const& id = "");
+    std::locale get_locale(std::string const& id = "");
 
 }}  // namespace leatherman::locale

--- a/locale/src/posix/locale.cc
+++ b/locale/src/posix/locale.cc
@@ -1,23 +1,11 @@
-// boost includes are not always warning-clean. Disable warnings that
-// cause problems before including the headers, then re-enable the warnings.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
-#include <boost/filesystem/path.hpp>
-#pragma GCC diagnostic pop
-
-#include <locale>
+#include <leatherman/locale/locale.hpp>
 
 namespace leatherman { namespace locale {
-    void set_locale(std::string const& id)
+    std::locale get_locale(std::string const& id)
     {
         // Windows uses boost::locale to generate a UTF-8 compatible locale. Other platforms
         // assume UTF-8 should be used, so we can avoid the boost::locale dependency here.
         // GCC 4.8 doesn't yet implement the std::locale(std::string const&) interface, so use c-str.
-        std::locale::global(std::locale(id.c_str()));
-
-        // Setup boost::filesystem to use the locale. By default on Windows, it uses wchar_t with
-        // the default system locale, resulting in 3- and 4-byte UTF characters being unsupported.
-        // Using the boost::locale's system default fixes that by using a UTF-8 compatible locale.
-        boost::filesystem::path::imbue(std::locale());
+        return std::locale(id.c_str());
     }
 }}  // namespace leatherman::locale

--- a/locale/src/windows/locale.cc
+++ b/locale/src/windows/locale.cc
@@ -1,23 +1,18 @@
+#include <leatherman/locale/locale.hpp>
+
 // boost includes are not always warning-clean. Disable warnings that
 // cause problems before including the headers, then re-enable the warnings.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
-#include <boost/filesystem/path.hpp>
 #include <boost/locale.hpp>
 #pragma GCC diagnostic pop
 
 namespace leatherman { namespace locale {
-    void set_locale(std::string const& id)
+    std::locale get_locale(std::string const& id)
     {
-        // Setup locales; this must be done on startup for any use of libfacter.
         // The system default locale is set with id == "", except on Windows boost::locale's
-        // generator uses a compatible UTF-8 equivalent. This results in UTF-8 being the default
-        // on all platforms.
-        std::locale::global(boost::locale::generator().generate(id));
-
-        // Setup boost::filesystem to use the locale. By default on Windows, it uses wchar_t with
-        // the default system locale, resulting in 3- and 4-byte UTF characters being unsupported.
-        // Using the boost::locale's system default fixes that by using a UTF-8 compatible locale.
-        boost::filesystem::path::imbue(std::locale());
+        // generator uses a compatible UTF-8 equivalent. Using boost results in UTF-8 being
+        // the default on all platforms.
+        return std::locale(boost::locale::generator().generate(id));
     }
 }}  // namespace leatherman::locale

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -1,6 +1,6 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS log)
+find_package(Boost 1.54 REQUIRED COMPONENTS system filesystem thread date_time log)
 
-add_leatherman_deps("${Boost_LOG_LIBRARY}")
+add_leatherman_deps("${Boost_SYSTEM_LIBRARY}" "${Boost_FILESYSTEM_LIBRARY}" "${Boost_THREAD_LIBRARY}" "${Boost_LOG_LIBRARY}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")
 
 leatherman_dependency(nowide)

--- a/logging/inc/leatherman/logging/logging.hpp
+++ b/logging/inc/leatherman/logging/logging.hpp
@@ -153,8 +153,9 @@ namespace leatherman { namespace logging {
      * Sets up logging for the given stream.
      * The logging level is set to warning by default.
      * @param dst Destination stream for logging output.
+     * @param locale The locale identifier to use for logging.
      */
-    void setup_logging(std::ostream &dst);
+    void setup_logging(std::ostream &dst, std::string locale = "");
 
     /**
      * Sets the current log level.

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -34,16 +34,16 @@ namespace leatherman { namespace logging {
     static bool g_colorize = false;
     static bool g_error_logged = false;
 
-    void setup_logging(ostream &dst)
+    void setup_logging(ostream &dst, string locale)
     {
-        // Initialize locale
-        leatherman::locale::set_locale();
-
         // Remove existing sinks before adding a new one
         auto core = boost::log::core::get();
         core->remove_all_sinks();
 
         auto sink = boost::log::add_console_log(dst, keywords::auto_flush = true);
+
+        // Imbue the logging sink with the requested locale.
+        sink->imbue(leatherman::locale::get_locale(locale));
 
         sink->set_formatter(
             expr::stream


### PR DESCRIPTION
Cthun uses stringstream for conversion of port numbers to string,
that's affected by setting locale globally - it introduces comma
separators for 4-digit integers. Separate setting locale for specific
uses out of initializing logging, so it can be incrementally enabled.