### PR TITLE
(FACT-914) Avoid std::locale on Solaris with GCC

### DIFF
--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -42,8 +42,11 @@ namespace leatherman { namespace logging {
 
         auto sink = boost::log::add_console_log(dst, keywords::auto_flush = true);
 
+#if !defined(__sun) || !defined(__GNUC__)
         // Imbue the logging sink with the requested locale.
+        // Locale in GCC is busted on Solaris, so skip it.
         sink->imbue(leatherman::locale::get_locale(locale));
+#endif
 
         sink->set_formatter(
             expr::stream


### PR DESCRIPTION
On Solaris when using GCC, std::locale is broken.
https://gcc.gnu.org/ml/gcc/2012-08/msg00284.html

Disable using std::locale on Solaris. The defaults support UTF-8.