### PR TITLE
(LTH-5) Add Boost.Chrono explicit dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - wget https://s3.amazonaws.com/kylo-pl-bucket/doxygen_install.tar.bz2
   - sudo tar xjvf doxygen_install.tar.bz2 --strip 1 -C /usr/local
   # Install dependencies of cfacter
-  - sudo apt-get -y install libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-regex1.55-dev libboost-date-time1.55-dev libboost-thread1.55-dev libboost-log1.55-dev libboost-locale1.55-dev
+  - sudo apt-get -y install libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-regex1.55-dev libboost-date-time1.55-dev libboost-thread1.55-dev libboost-log1.55-dev libboost-locale1.55-dev libboost-chrono1.55-dev
   - wget https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1_install.tar.bz2
   - sudo tar xjvf yaml-cpp-0.5.1_install.tar.bz2 --strip 1 -C /usr/local
   # Install libblkid-dev

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -1,6 +1,6 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS system filesystem thread date_time log)
+find_package(Boost 1.54 REQUIRED COMPONENTS system filesystem thread date_time log chrono)
 
-add_leatherman_deps("${Boost_SYSTEM_LIBRARY}" "${Boost_FILESYSTEM_LIBRARY}" "${Boost_THREAD_LIBRARY}" "${Boost_LOG_LIBRARY}")
+add_leatherman_deps("${Boost_SYSTEM_LIBRARY}" "${Boost_FILESYSTEM_LIBRARY}" "${Boost_THREAD_LIBRARY}" "${Boost_DATE_TIME_LIBRARY}" "${Boost_LOG_LIBRARY}" "${Boost_CHRONO}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")
 
 leatherman_dependency(nowide)


### PR DESCRIPTION
Boost.Log has an implicit dependency on Boost.Chrono. When we statically link,
this gets resolved at compile time and isn't an issue. On most platforms when
we dynamically link, the Boost library location is in LD_LIBRARY_PATH, and
again Boost.Chrono is found.

On Solaris neither of those things are true, which exposed a runtime
dependency on libboost_chrono.so. Resolve this by explicitly depending on the
Chrono library in Leatherman's Logging library.