### PR TITLE
(LTH-1) Support 'make install' in leatherman

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ endif()
 defoption(LEATHERMAN_DEFAULT_ENABLE "Should Leatherman libraries all be built by default" ${LEATHERMAN_TOPLEVEL})
 defoption(LEATHERMAN_DEBUG "Enable verbose logging messages from leatherman macros" FALSE)
 defoption(LEATHERMAN_ENABLE_TESTING "Build the leatherman test binary" ${LEATHERMAN_DEFAULT_ENABLE})
+defoption(LEATHERMAN_INSTALL "Install the leatherman libraries and headers" ${LEATHERMAN_DEFAULT_ENABLE})
+
+set(BUILDING_LEATHERMAN TRUE)
 
 #As with most things, we rely on the containing project to set up the
 #common flags
@@ -57,4 +60,19 @@ if(LEATHERMAN_ENABLE_TESTING)
 	enable_cppcheck()
 	enable_cpplint()
     endif()
+endif()
+
+# Install the cmake files we need for consumers
+if (LEATHERMAN_INSTALL)
+    set(CMAKE_FILES
+        cmake/cflags.cmake
+        cmake/leatherman.cmake
+        cmake/options.cmake
+        cmake/leatherman_config.cmake
+    )
+    install(FILES ${CMAKE_FILES} DESTINATION "lib/cmake/leatherman/cmake/")
+
+    configure_file(LeathermanConfig.cmake.in "${PROJECT_BINARY_DIR}/LeathermanConfig.cmake" @ONLY)
+    install(FILES "${PROJECT_BINARY_DIR}/LeathermanConfig.cmake" DESTINATION "lib/cmake/leatherman")
+    install(EXPORT LeathermanLibraries DESTINATION "lib/cmake/leatherman")
 endif()

--- a/LeathermanConfig.cmake.in
+++ b/LeathermanConfig.cmake.in
@@ -1,0 +1,33 @@
+get_filename_component(current_directory ${CMAKE_CURRENT_LIST_FILE} DIRECTORY)
+list(APPEND CMAKE_MODULE_PATH "${current_directory}/cmake")
+include(leatherman_config)
+include(options)
+include("${current_directory}/LeathermanLibraries.cmake")
+
+get_filename_component(LEATHERMAN_PREFIX "${current_directory}/../../../" ABSOLUTE)
+
+@LEATHERMAN_COMPONENTS@
+
+debug("Selected components: ${Leatherman_FIND_COMPONENTS}")
+foreach(component ${Leatherman_FIND_COMPONENTS})
+    string(TOUPPER "${component}" id_upper)
+    set(exclude_var "LEATHERMAN_EXCLUDE_${id_upper}")
+    set(include_var "LEATHERMAN_${id_upper}_INCLUDE")
+    set(libs_var "LEATHERMAN_${id_upper}_LIBS")
+    debug("Exclude variable ${exclude_var} is ${${exclude_var}}")
+    if(${${exclude_var}})
+        debug("Excluding values for ${id_upper}")
+        debug("* include is ${include_var}: ${${include_var}}")
+        debug("* library is ${libs_var}: ${${libs_var}}")
+    else()
+        debug("Appending values for ${id_upper} to common vars")
+        debug("* include is ${${include_var}}")
+        debug("* library is ${${libs_var}}")
+        list(APPEND LEATHERMAN_INCLUDE_DIRS ${${include_var}})
+        list(APPEND LEATHERMAN_LIBRARIES ${${libs_var}})
+    endif()
+endforeach()
+
+list(REVERSE LEATHERMAN_LIBRARIES)
+list(REMOVE_DUPLICATES LEATHERMAN_INCLUDE_DIRS)
+set(LEATHERMAN_MODULE_DIR "${current_directory}/cmake")

--- a/catch/CMakeLists.txt
+++ b/catch/CMakeLists.txt
@@ -1,2 +1,13 @@
-# Just point the user at our vendored catch. Nothing else to do here
-set(${include_var} "${PROJECT_SOURCE_DIR}/vendor/catch/include" PARENT_SCOPE)
+if (BUILDING_LEATHERMAN)
+    # Just point the user at our vendored catch. Nothing else to do here
+    set(include_dir "${PROJECT_SOURCE_DIR}/vendor/catch/include")
+    set(${include_var} ${include_dir} PARENT_SCOPE)
+
+    # Because we're weird and vendored, we need to bypass the normal
+    # leatherman install helpers.
+    if (LEATHERMAN_INSTALL)
+        install(FILES "${include_dir}/catch.hpp" DESTINATION "include/leatherman/vendor/catch")
+    endif()
+else()
+    set(${include_var} "${LEATHERMAN_PREFIX}/include/leatherman/vendor/catch")
+endif()

--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -45,25 +45,25 @@ macro(leatherman_dependency library)
     set(dep_include "LEATHERMAN_${name}_INCLUDE")
 
     if(${${option}})
-	debug("Found ${library} as ${name}, using it in current context")
-	if (NOT "" STREQUAL "${${dep_deps}}")
-	    debug("Adding ${${dep_deps}} to deps for ${dirname}")
-	    list(APPEND ${deps_var} ${${dep_deps}})
-	    export_var(${deps_var})
-	endif()
-	if (NOT "" STREQUAL "${${dep_lib}}")
-	    debug("Adding ${${dep_lib}} to deps for ${dirname}")
-	    list(APPEND ${deps_var} ${${dep_lib}})
-	    export_var(${deps_var})
-	endif()
-	if (NOT "" STREQUAL "${${dep_include}}")
-	    debug("Adding ${${dep_include}} to include directories for ${dirname}")
-	    list(APPEND ${include_var} ${${dep_include}})
-	    list(REMOVE_DUPLICATES ${include_var})
-	    export_var(${include_var})
-	endif()
+        debug("Found ${library} as ${name}, using it in current context")
+        if (NOT "" STREQUAL "${${dep_deps}}")
+            debug("Adding ${${dep_deps}} to deps for ${dirname}")
+            list(APPEND ${deps_var} ${${dep_deps}})
+            export_var(${deps_var})
+        endif()
+        if (NOT "" STREQUAL "${${dep_lib}}")
+            debug("Adding ${${dep_lib}} to deps for ${dirname}")
+            list(APPEND ${deps_var} ${${dep_lib}})
+            export_var(${deps_var})
+        endif()
+        if (NOT "" STREQUAL "${${dep_include}}")
+            debug("Adding ${${dep_include}} to include directories for ${dirname}")
+            list(APPEND ${include_var} ${${dep_include}})
+            list(REMOVE_DUPLICATES ${include_var})
+            export_var(${include_var})
+        endif()
     else()
-	message(FATAL_ERROR "${library} not found as a dependency for ${dirname}")
+        message(FATAL_ERROR "${library} not found as a dependency for ${dirname}")
     endif()
 endmacro()
 
@@ -89,11 +89,11 @@ endmacro()
 # leatherman unit test executable.
 macro(add_leatherman_test)
     foreach(FILE ${ARGV})
-	if (IS_ABSOLUTE FILE)
-	    list(APPEND LEATHERMAN_TEST_SRCS "${FILE}")
-	else()
-	    list(APPEND LEATHERMAN_TEST_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}")
-	endif()
+        if (IS_ABSOLUTE FILE)
+            list(APPEND LEATHERMAN_TEST_SRCS "${FILE}")
+        else()
+            list(APPEND LEATHERMAN_TEST_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}")
+        endif()
     endforeach()
     export_var(LEATHERMAN_TEST_SRCS)
 endmacro()
@@ -128,49 +128,49 @@ macro(add_leatherman_dir dir)
 
     defoption(${option} "Should ${dir} be built and used?" ${LEATHERMAN_DEFAULT_ENABLE})
     if (${${option}})
-	set(include_var "LEATHERMAN_${id_upper}_INCLUDE")
-	set(lib_var "LEATHERMAN_${id_upper}_LIB")
-	set(deps_var "LEATHERMAN_${id_upper}_DEPS")
+        set(include_var "LEATHERMAN_${id_upper}_INCLUDE")
+        set(lib_var "LEATHERMAN_${id_upper}_LIB")
+        set(deps_var "LEATHERMAN_${id_upper}_DEPS")
  
-	set(${include_var} ${include_dir})
-	set(${lib_var} "") # if library is built, this will be set automatically
+        set(${include_var} ${include_dir})
+        set(${lib_var} "") # if library is built, this will be set automatically
 
-	# By adding the subdirectory after setting all variables, but
-	# before exporting, we give the library an opportunity to
-	# munge them (for example, to add vendor dirs)
-	add_subdirectory("${dir}")
+        # By adding the subdirectory after setting all variables, but
+        # before exporting, we give the library an opportunity to
+        # munge them (for example, to add vendor dirs)
+        add_subdirectory("${dir}")
 
-	# We set this one afterwards because it doesn't need
-	# overriding
-	#
-	# We put deps before libs. This is backwards on purpose. We
-	# later reverse the entire libraries list in order to ensure
-	# proper link order. Ideally we could put things in the
-	# correct order directly, but CMake de-duplicates link lines
-	# in ways that just make this a sad, sad process.
-	set(libs_var "LEATHERMAN_${id_upper}_LIBS")
-	set(${libs_var} ${${deps_var}} ${${lib_var}})
+        # We set this one afterwards because it doesn't need
+        # overriding
+        #
+        # We put deps before libs. This is backwards on purpose. We
+        # later reverse the entire libraries list in order to ensure
+        # proper link order. Ideally we could put things in the
+        # correct order directly, but CMake de-duplicates link lines
+        # in ways that just make this a sad, sad process.
+        set(libs_var "LEATHERMAN_${id_upper}_LIBS")
+        set(${libs_var} ${${deps_var}} ${${lib_var}})
 
-	if(NOT "${ARGV1}" STREQUAL EXCLUDE_FROM_VARS)
-	    debug("Appending values for ${id_upper} to common vars")
-	    list(APPEND LEATHERMAN_INCLUDE_DIRS ${${include_var}})
-	    list(APPEND LEATHERMAN_LIBRARIES ${${libs_var}})
-	else()
-	    debug("Excluding values for ${id_upper} from common vars")
-	endif()
+        if(NOT "${ARGV1}" STREQUAL EXCLUDE_FROM_VARS)
+            debug("Appending values for ${id_upper} to common vars")
+            list(APPEND LEATHERMAN_INCLUDE_DIRS ${${include_var}})
+            list(APPEND LEATHERMAN_LIBRARIES ${${libs_var}})
+        else()
+            debug("Excluding values for ${id_upper} from common vars")
+        endif()
 
 
-	# Put our link line into the right order.
+        # Put our link line into the right order.
         if("${${libs_var}}")
             list(REVERSE ${libs_var})
         endif()
 
-	export_var(${include_var})
-	export_var(${lib_var})
-	export_var(${libs_var})
-	export_var(${deps_var})
+        export_var(${include_var})
+        export_var(${lib_var})
+        export_var(${libs_var})
+        export_var(${deps_var})
 
-	# Enable cppcheck on this library	
-	list(APPEND LEATHERMAN_CPPCHECK_DIRS "${CMAKE_SOURCE_DIR}/${dir}")
+        # Enable cppcheck on this library
+        list(APPEND LEATHERMAN_CPPCHECK_DIRS "${CMAKE_SOURCE_DIR}/${dir}")
     endif()
 endmacro(add_leatherman_dir)

--- a/cmake/leatherman_config.cmake
+++ b/cmake/leatherman_config.cmake
@@ -1,0 +1,80 @@
+include(leatherman)
+
+# Usage: add_leatherman_deps(${DEP1_LIB} ${DEP2_LIB})
+#
+# Append to the LEATHERMAN_<LIBRARY>_DEPS variable.
+macro(add_leatherman_deps)
+    list(APPEND ${deps_var} ${ARGV})
+endmacro()
+
+# Usage: add_leatherman_includes(${DIR1} ${DIR2})
+#
+# Append to the LEATHERMAN_<LIBRARY>_INCLUDE variable
+macro(add_leatherman_includes)
+    list(APPEND ${include_var} ${ARGV})
+    list(REMOVE_DUPLICATES ${include_var})
+endmacro()
+
+# Usage: leatherman_dependency("libname")
+#
+# Automatically handle include directories and library linking for the
+# given leatherman library.
+#
+# Will throw a fatal error if the dependency cannot be found.
+macro(leatherman_dependency library)
+    string(MAKE_C_IDENTIFIER "${library}" lib)
+    string(TOUPPER "${lib}" name)
+    set(option "LEATHERMAN_USE_${name}")
+    set(dep_lib "LEATHERMAN_${name}_LIB")
+    set(dep_deps "LEATHERMAN_${name}_DEPS")
+    set(dep_include "LEATHERMAN_${name}_INCLUDE")
+
+    if (NOT "" STREQUAL "${${dep_deps}}")
+        debug("Adding ${${dep_deps}} to deps for ${id_upper}")
+        list(APPEND ${deps_var} ${${dep_deps}})
+    endif()
+    if (NOT "" STREQUAL "${${dep_lib}}")
+        debug("Adding ${${dep_lib}} to deps for ${id_upper}")
+        list(APPEND ${deps_var} ${${dep_lib}})
+    endif()
+    if (NOT "" STREQUAL "${${dep_include}}")
+        debug("Adding ${${dep_include}} to include directories for ${id_upper}")
+        list(APPEND ${include_var} ${${dep_include}})
+        list(REMOVE_DUPLICATES ${include_var})
+    endif()
+endmacro()
+
+macro(add_leatherman_library)
+    set(${lib_var} "${libname}")
+endmacro()
+
+macro(add_leatherman_headers)
+endmacro()
+
+macro(add_leatherman_test)
+endmacro()
+
+macro(leatherman_component id)
+    string(TOUPPER "${id}" id_upper)
+    set(include_var "LEATHERMAN_${id_upper}_INCLUDE")
+    set(lib_var "LEATHERMAN_${id_upper}_LIB")
+    set(deps_var "LEATHERMAN_${id_upper}_DEPS")
+    set(include_dir "${LEATHERMAN_PREFIX}/include")
+    set(libname "leatherman_${id}")
+    set(${include_var} ${include_dir})
+    set(${lib_var} "")
+
+    include("${current_directory}/${id}.cmake")
+
+    set(libs_var "LEATHERMAN_${id_upper}_LIBS")
+    set(${libs_var} ${${deps_var}} ${${lib_var}})
+
+    if(NOT "${${libs_var}}" STREQUAL "")
+        list(REVERSE ${libs_var})
+    endif()
+
+    if("${ARGV1}" STREQUAL EXCLUDE_FROM_VARS)
+        set(exclude_var "LEATHERMAN_EXCLUDE_${id_upper}")
+        set(${exclude_var} TRUE)
+    endif()
+endmacro()

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -13,4 +13,4 @@ if (WIN32)
 endif()
 
 add_leatherman_library(${LEATHERMAN_LOCALE_SRCS})
-
+add_leatherman_headers(inc/leatherman)

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -6,6 +6,10 @@ add_leatherman_includes("${Boost_INCLUDE_DIRS}")
 leatherman_dependency(nowide)
 leatherman_dependency(locale)
 
-leatherman_logging_namespace("leatherman.logging")
+if (BUILDING_LEATHERMAN)
+    leatherman_logging_namespace("leatherman.logging")
+endif()
+
 add_leatherman_library(src/logging.cc)
 add_leatherman_test(tests/logging.cc)
+add_leatherman_headers(inc/leatherman)

--- a/nowide/CMakeLists.txt
+++ b/nowide/CMakeLists.txt
@@ -1,12 +1,46 @@
-set(${include_var} "${PROJECT_SOURCE_DIR}/vendor/boost-nowide" PARENT_SCOPE)
-if (WIN32)
-    set(${lib_var} nowide-shared PARENT_SCOPE)
-else()
+if (BUILDING_LEATHERMAN)
+    set(${include_var} "${PROJECT_SOURCE_DIR}/vendor/boost-nowide" PARENT_SCOPE)
+    if (WIN32)
+        set(${lib_var} nowide-shared PARENT_SCOPE)
+    endif()
+
     set(BOOST_NOWIDE_SKIP_TESTS ON CACHE BOOL "Disable tests in Boost.Nowide")
+
+    # Disable installing Boost.Nowide so we don't pollute the
+    # installation. We will handle installing the appropriate header files
+    # to our own vendor include dir.
+    set(BOOST_NOWIDE_SKIP_INSTALL ON CACHE BOOL "Disable installing Boost.Nowide")
+
+    # have to specify a bindir since this isn't actually a subdirectory of us
+    add_subdirectory("../vendor/boost-nowide" "../vendor/boost-nowide")
+
+    if (LEATHERMAN_INSTALL)
+        install(DIRECTORY "../vendor/boost-nowide/boost" DESTINATION "include/leatherman/vendor/boost-nowide")
+
+        if (WIN32)
+            set(bindir "${CMAKE_CURRENT_BINARY_DIR}/../vendor/boost-nowide")
+            # Have to install as FILES instead of TARGETS because the
+            # target isn't in this CMake file
+            get_target_property(output_name nowide-shared OUTPUT_NAME)
+            install(FILES "${bindir}/${CMAKE_IMPORT_LIBRARY_PREFIX}${output_name}${CMAKE_IMPORT_LIBRARY_SUFFIX}" DESTINATION "lib/leatherman")
+            install(FILES "${bindir}/${CMAKE_SHARED_LIBRARY_PREFIX}${output_name}${CMAKE_SHARED_LIBRARY_SUFFIX}" DESTINATION "bin")
+        endif()
+    endif()
+else()
+    set(${include_var} "${LEATHERMAN_PREFIX}/include/leatherman/vendor/boost-nowide")
+
+    if (WIN32)
+        set(${lib_var} nowide-shared)
+        add_library(nowide-shared SHARED IMPORTED)
+        find_library( NOWIDE_LIB
+            NAMES libnowide
+            PATHS "${LEATHERMAN_PREFIX}/lib/leatherman"
+            NO_DEFAULT_PATH
+            )
+        set_target_properties(nowide-shared PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+            IMPORTED_LOCATION "${LEATHERMAN_PREFIX}/bin/libnowide.dll"
+            IMPORTED_IMPLIB ${NOWIDE_LIB}
+        )
+    endif()
 endif()
-
-# Disable installing Boost.Nowide so we don't pollute the installation.
-set(BOOST_NOWIDE_SKIP_INSTALL ON CACHE BOOL "Disable installing Boost.Nowide")
-
-# have to specify a bindir since this isn't actually a subdirectory of us
-add_subdirectory("../vendor/boost-nowide" "../vendor/boost-nowide")


### PR DESCRIPTION
This adds the frameworks necessary to be able to install leatherman, as well as load it with the normal CMake `find_package` facilities. A companion PR to facter demonstrates the usage.

