### PR TITLE
(LTH-8) Make logging line numbers configurable

### DIFF
--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -9,6 +9,13 @@ macro(leatherman_logging_namespace namespace)
     add_definitions("-DLEATHERMAN_LOGGING_NAMESPACE=\"${namespace}\"")
 endmacro()
 
+# Usage: leatherman_logging_line_numbers()
+#
+# Sets the LEATHERMAN_LOGGING_LINE_NUMBERS preprocessor definition.
+macro(leatherman_logging_line_numbers)
+    add_definitions("-DLEATHERMAN_LOGGING_LINE_NUMBERS")
+endmacro()
+
 # Usage: debug("Something cool is happening")
 #
 # Print message if LEATHERMAN_DEBUG is set. Used to introspect macro

--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -8,8 +8,9 @@ leatherman_dependency(locale)
 
 if (BUILDING_LEATHERMAN)
     leatherman_logging_namespace("leatherman.logging")
+    leatherman_logging_line_numbers()
 endif()
 
 add_leatherman_library(src/logging.cc)
-add_leatherman_test(tests/logging.cc)
+add_leatherman_test(tests/logging.cc tests/logging_lines.cc)
 add_leatherman_headers(inc/leatherman)

--- a/logging/inc/leatherman/logging/logging.hpp
+++ b/logging/inc/leatherman/logging/logging.hpp
@@ -34,10 +34,17 @@
  * @param format The format message.
  * @param ... The format message parameters.
  */
+#ifdef LEATHERMAN_LOGGING_LINE_NUMBERS
 #define LOG_MESSAGE(level, line_num, format, ...) \
     if (leatherman::logging::is_enabled(level)) { \
         leatherman::logging::log(LOG_NAMESPACE, level, line_num, format, ##__VA_ARGS__); \
     }
+#else
+#define LOG_MESSAGE(level, line_num, format, ...) \
+    if (leatherman::logging::is_enabled(level)) { \
+        leatherman::logging::log(LOG_NAMESPACE, level, format, ##__VA_ARGS__); \
+    }
+#endif
 /**
  * Logs a trace message.
  * @param format The format message.
@@ -213,6 +220,14 @@ namespace leatherman { namespace logging {
      * Logs a given message to the given logger.
      * @param logger The logger to log the message to.
      * @param level The logging level to log with.
+     * @param message The message to log.
+     */
+    void log(const std::string &logger, log_level level, std::string const& message);
+
+    /**
+     * Logs a given message to the given logger with the specified line number.
+     * @param logger The logger to log the message to.
+     * @param level The logging level to log with.
      * @param line_num The source line number of the logging call.
      * @param message The message to log.
      */
@@ -222,6 +237,14 @@ namespace leatherman { namespace logging {
      * Logs a given format message to the given logger.
      * @param logger The logger to log the message to.
      * @param level The logging level to log with.
+     * @param message The message being formatted.
+     */
+    void log(const std::string &logger, log_level level, boost::format& message);
+
+    /**
+     * Logs a given format message to the given logger with the specified line number.
+     * @param logger The logger to log the message to.
+     * @param level The logging level to log with.
      * @param line_num The source line number of the logging call.
      * @param message The message being formatted.
      */
@@ -229,6 +252,23 @@ namespace leatherman { namespace logging {
 
     /**
      * Logs a given format message to the given logger.
+     * @tparam T The type of the first argument.
+     * @tparam TArgs The types of the remaining arguments.
+     * @param logger The logger to log to.
+     * @param level The logging level to log with.
+     * @param message The message being formatted.
+     * @param arg The first argument to the message.
+     * @param args The remaining arguments to the message.
+     */
+    template <typename T, typename... TArgs>
+    void log(const std::string &logger, log_level level, boost::format& message, T arg, TArgs... args)
+    {
+        message % arg;
+        log(logger, level, message, std::forward<TArgs>(args)...);
+    }
+
+    /**
+     * Logs a given format message to the given logger with the specified line number.
      * @tparam T The type of the first argument.
      * @tparam TArgs The types of the remaining arguments.
      * @param logger The logger to log to.
@@ -247,6 +287,21 @@ namespace leatherman { namespace logging {
 
     /**
      * Logs a given format message to the given logger.
+     * @tparam TArgs The types of the arguments to format the message with.
+     * @param logger The logger to log to.
+     * @param level The logging level to log with.
+     * @param format The message format.
+     * @param args The remaining arguments to the message.
+     */
+    template <typename... TArgs>
+    void log(const std::string &logger, log_level level, std::string const& format, TArgs... args)
+    {
+        boost::format message(format);
+        log(logger, level, message, std::forward<TArgs>(args)...);
+    }
+
+    /**
+     * Logs a given format message to the given logger with the specified line number.
      * @tparam TArgs The types of the arguments to format the message with.
      * @param logger The logger to log to.
      * @param level The logging level to log with.

--- a/logging/inc/leatherman/logging/logging.hpp
+++ b/logging/inc/leatherman/logging/logging.hpp
@@ -42,7 +42,7 @@
 #else
 #define LOG_MESSAGE(level, line_num, format, ...) \
     if (leatherman::logging::is_enabled(level)) { \
-        leatherman::logging::log(LOG_NAMESPACE, level, format, ##__VA_ARGS__); \
+        leatherman::logging::log(LOG_NAMESPACE, level, 0, format, ##__VA_ARGS__); \
     }
 #endif
 /**
@@ -217,15 +217,7 @@ namespace leatherman { namespace logging {
     void clear_error_logged_flag();
 
     /**
-     * Logs a given message to the given logger.
-     * @param logger The logger to log the message to.
-     * @param level The logging level to log with.
-     * @param message The message to log.
-     */
-    void log(const std::string &logger, log_level level, std::string const& message);
-
-    /**
-     * Logs a given message to the given logger with the specified line number.
+     * Logs a given message to the given logger with the specified line number (if > 0).
      * @param logger The logger to log the message to.
      * @param level The logging level to log with.
      * @param line_num The source line number of the logging call.
@@ -234,15 +226,7 @@ namespace leatherman { namespace logging {
     void log(const std::string &logger, log_level level, int line_num, std::string const& message);
 
     /**
-     * Logs a given format message to the given logger.
-     * @param logger The logger to log the message to.
-     * @param level The logging level to log with.
-     * @param message The message being formatted.
-     */
-    void log(const std::string &logger, log_level level, boost::format& message);
-
-    /**
-     * Logs a given format message to the given logger with the specified line number.
+     * Logs a given format message to the given logger with the specified line number (if > 0).
      * @param logger The logger to log the message to.
      * @param level The logging level to log with.
      * @param line_num The source line number of the logging call.
@@ -251,24 +235,7 @@ namespace leatherman { namespace logging {
     void log(const std::string &logger, log_level level, int line_num, boost::format& message);
 
     /**
-     * Logs a given format message to the given logger.
-     * @tparam T The type of the first argument.
-     * @tparam TArgs The types of the remaining arguments.
-     * @param logger The logger to log to.
-     * @param level The logging level to log with.
-     * @param message The message being formatted.
-     * @param arg The first argument to the message.
-     * @param args The remaining arguments to the message.
-     */
-    template <typename T, typename... TArgs>
-    void log(const std::string &logger, log_level level, boost::format& message, T arg, TArgs... args)
-    {
-        message % arg;
-        log(logger, level, message, std::forward<TArgs>(args)...);
-    }
-
-    /**
-     * Logs a given format message to the given logger with the specified line number.
+     * Logs a given format message to the given logger with the specified line number (if > 0).
      * @tparam T The type of the first argument.
      * @tparam TArgs The types of the remaining arguments.
      * @param logger The logger to log to.
@@ -286,22 +253,7 @@ namespace leatherman { namespace logging {
     }
 
     /**
-     * Logs a given format message to the given logger.
-     * @tparam TArgs The types of the arguments to format the message with.
-     * @param logger The logger to log to.
-     * @param level The logging level to log with.
-     * @param format The message format.
-     * @param args The remaining arguments to the message.
-     */
-    template <typename... TArgs>
-    void log(const std::string &logger, log_level level, std::string const& format, TArgs... args)
-    {
-        boost::format message(format);
-        log(logger, level, message, std::forward<TArgs>(args)...);
-    }
-
-    /**
-     * Logs a given format message to the given logger with the specified line number.
+     * Logs a given format message to the given logger with the specified line number (if > 0).
      * @tparam TArgs The types of the arguments to format the message with.
      * @param logger The logger to log to.
      * @param level The logging level to log with.

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -139,28 +139,9 @@ namespace leatherman { namespace logging {
         return g_colorize ? reset : none;
     }
 
-    void log(const string &logger, log_level level, boost::format& message)
-    {
-        log(logger, level, message.str());
-    }
-
     void log(const string &logger, log_level level, int line_num, boost::format& message)
     {
         log(logger, level, line_num, message.str());
-    }
-
-    void log(const string &logger, log_level level, string const& message)
-    {
-        if (level >= log_level::error) {
-            g_error_logged = true;
-        }
-        if (!is_enabled(level) || (g_callback && !g_callback(level, message))) {
-            return;
-        }
-
-        src::severity_logger<log_level> slg;
-        slg.add_attribute("Namespace", attrs::constant<string>(logger));
-        BOOST_LOG_SEV(slg, level) << " - "  << colorize(level) << message << colorize();
     }
 
     void log(const string &logger, log_level level, int line_num, string const& message)
@@ -174,7 +155,7 @@ namespace leatherman { namespace logging {
 
         src::severity_logger<log_level> slg;
         slg.add_attribute("Namespace", attrs::constant<string>(logger));
-        BOOST_LOG_SEV(slg, level) << ":" << line_num << " - "  << colorize(level) << message << colorize();
+        BOOST_LOG_SEV(slg, level) << (line_num > 0 ? ":"+to_string(line_num) : "") << " - "  << colorize(level) << message << colorize();
     }
 
     istream& operator>>(istream& in, log_level& level)

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -53,7 +53,7 @@ namespace leatherman { namespace logging {
                 << expr::format_date_time<boost::posix_time::ptime>("TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
                 << " " << left << setfill(' ') << setw(5) << leatherman::logging::log_level_attr
                 << " " << leatherman::logging::namespace_attr
-                << ":" << expr::smessage);
+                << expr::smessage);
 
         boost::log::add_common_attributes();
 
@@ -139,9 +139,28 @@ namespace leatherman { namespace logging {
         return g_colorize ? reset : none;
     }
 
+    void log(const string &logger, log_level level, boost::format& message)
+    {
+        log(logger, level, message.str());
+    }
+
     void log(const string &logger, log_level level, int line_num, boost::format& message)
     {
         log(logger, level, line_num, message.str());
+    }
+
+    void log(const string &logger, log_level level, string const& message)
+    {
+        if (level >= log_level::error) {
+            g_error_logged = true;
+        }
+        if (!is_enabled(level) || (g_callback && !g_callback(level, message))) {
+            return;
+        }
+
+        src::severity_logger<log_level> slg;
+        slg.add_attribute("Namespace", attrs::constant<string>(logger));
+        BOOST_LOG_SEV(slg, level) << " - "  << colorize(level) << message << colorize();
     }
 
     void log(const string &logger, log_level level, int line_num, string const& message)
@@ -155,7 +174,7 @@ namespace leatherman { namespace logging {
 
         src::severity_logger<log_level> slg;
         slg.add_attribute("Namespace", attrs::constant<string>(logger));
-        BOOST_LOG_SEV(slg, level) << line_num << " - "  << colorize(level) << message << colorize();
+        BOOST_LOG_SEV(slg, level) << ":" << line_num << " - "  << colorize(level) << message << colorize();
     }
 
     istream& operator>>(istream& in, log_level& level)

--- a/logging/tests/logging.cc
+++ b/logging/tests/logging.cc
@@ -64,7 +64,7 @@ SCENARIO("logging with a TRACE level") {
     LOG_TRACE("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "TRACE");
     REQUIRE(context._appender->_message == string(colorize(log_level::trace)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::trace, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::trace, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "TRACE");
     REQUIRE(context._appender->_message == string(colorize(log_level::trace)) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
@@ -76,7 +76,7 @@ SCENARIO("logging with a DEBUG level") {
     LOG_DEBUG("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "DEBUG");
     REQUIRE(context._appender->_message == string(colorize(log_level::debug)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::debug, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::debug, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "DEBUG");
     REQUIRE(context._appender->_message == string(colorize(log_level::debug)) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
@@ -88,7 +88,7 @@ SCENARIO("logging with an INFO level") {
     LOG_INFO("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "INFO");
     REQUIRE(context._appender->_message == string(colorize(log_level::info)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::info, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::info, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "INFO");
     REQUIRE(context._appender->_message == string(colorize(log_level::info)) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
@@ -100,7 +100,7 @@ SCENARIO("logging with a WARNING level") {
     LOG_WARNING("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "WARN");
     REQUIRE(context._appender->_message == string(colorize(log_level::warning)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::warning, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::warning, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "WARN");
     REQUIRE(context._appender->_message == string(colorize(log_level::warning)) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
@@ -112,7 +112,7 @@ SCENARIO("logging with an ERROR level") {
     LOG_ERROR("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "ERROR");
     REQUIRE(context._appender->_message == string(colorize(log_level::error)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::error, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::error, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "ERROR");
     REQUIRE(context._appender->_message == string(colorize(log_level::error)) + " - testing 1 2 3" + colorize());
     REQUIRE(error_has_been_logged());
@@ -124,7 +124,7 @@ SCENARIO("logging with a FATAL level") {
     LOG_FATAL("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "FATAL");
     REQUIRE(context._appender->_message == string(colorize(log_level::fatal)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::fatal, "testing %1% %2% %3%", 1, "2", 3.0);
+    log("test", log_level::fatal, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "FATAL");
     REQUIRE(context._appender->_message == string(colorize(log_level::fatal)) + " - testing 1 2 3" + colorize());
     REQUIRE(error_has_been_logged());

--- a/logging/tests/logging_lines.cc
+++ b/logging/tests/logging_lines.cc
@@ -1,4 +1,5 @@
 #include <catch.hpp>
+#define LEATHERMAN_LOGGING_LINE_NUMBERS
 #include <leatherman/logging/logging.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
 #include <boost/log/sinks/basic_sink_backend.hpp>
@@ -58,79 +59,85 @@ struct logging_test_context
     boost::shared_ptr<sink_t> _sink;
 };
 
-SCENARIO("logging with a TRACE level") {
+SCENARIO("logging with a TRACE level with line numbers") {
     logging_test_context context;
     REQUIRE(LOG_IS_TRACE_ENABLED());
+    int line_num = __LINE__ + 1;
     LOG_TRACE("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "TRACE");
-    REQUIRE(context._appender->_message == string(colorize(log_level::trace)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::trace, "testing %1% %2% %3%", 1, "2", 3.0);
+    REQUIRE(context._appender->_message == string(colorize(log_level::trace)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
+    log("test", log_level::trace, line_num, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "TRACE");
-    REQUIRE(context._appender->_message == string(colorize(log_level::trace)) + " - testing 1 2 3" + colorize());
+    REQUIRE(context._appender->_message == string(colorize(log_level::trace)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
 }
 
-SCENARIO("logging with a DEBUG level") {
+SCENARIO("logging with a DEBUG level with line numbers") {
     logging_test_context context;
     REQUIRE(LOG_IS_DEBUG_ENABLED());
+    int line_num = __LINE__ + 1;
     LOG_DEBUG("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "DEBUG");
-    REQUIRE(context._appender->_message == string(colorize(log_level::debug)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::debug, "testing %1% %2% %3%", 1, "2", 3.0);
+    REQUIRE(context._appender->_message == string(colorize(log_level::debug)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
+    log("test", log_level::debug, line_num, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "DEBUG");
-    REQUIRE(context._appender->_message == string(colorize(log_level::debug)) + " - testing 1 2 3" + colorize());
+    REQUIRE(context._appender->_message == string(colorize(log_level::debug)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
 }
 
-SCENARIO("logging with an INFO level") {
+SCENARIO("logging with an INFO level with line numbers") {
     logging_test_context context;
     REQUIRE(LOG_IS_INFO_ENABLED());
+    int line_num = __LINE__ + 1;
     LOG_INFO("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "INFO");
-    REQUIRE(context._appender->_message == string(colorize(log_level::info)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::info, "testing %1% %2% %3%", 1, "2", 3.0);
+    REQUIRE(context._appender->_message == string(colorize(log_level::info)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
+    log("test", log_level::info, line_num, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "INFO");
-    REQUIRE(context._appender->_message == string(colorize(log_level::info)) + " - testing 1 2 3" + colorize());
+    REQUIRE(context._appender->_message == string(colorize(log_level::info)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
 }
 
-SCENARIO("logging with a WARNING level") {
+SCENARIO("logging with a WARNING level with line numbers") {
     logging_test_context context;
     REQUIRE(LOG_IS_WARNING_ENABLED());
+    int line_num = __LINE__ + 1;
     LOG_WARNING("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "WARN");
-    REQUIRE(context._appender->_message == string(colorize(log_level::warning)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::warning, "testing %1% %2% %3%", 1, "2", 3.0);
+    REQUIRE(context._appender->_message == string(colorize(log_level::warning)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
+    log("test", log_level::warning, line_num, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "WARN");
-    REQUIRE(context._appender->_message == string(colorize(log_level::warning)) + " - testing 1 2 3" + colorize());
+    REQUIRE(context._appender->_message == string(colorize(log_level::warning)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
     REQUIRE_FALSE(error_has_been_logged());
 }
 
-SCENARIO("logging with an ERROR level") {
+SCENARIO("logging with an ERROR level with line numbers") {
     logging_test_context context;
     REQUIRE(LOG_IS_ERROR_ENABLED());
+    int line_num = __LINE__ + 1;
     LOG_ERROR("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "ERROR");
-    REQUIRE(context._appender->_message == string(colorize(log_level::error)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::error, "testing %1% %2% %3%", 1, "2", 3.0);
+    REQUIRE(context._appender->_message == string(colorize(log_level::error)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
+    log("test", log_level::error, line_num, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "ERROR");
-    REQUIRE(context._appender->_message == string(colorize(log_level::error)) + " - testing 1 2 3" + colorize());
+    REQUIRE(context._appender->_message == string(colorize(log_level::error)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
     REQUIRE(error_has_been_logged());
 }
 
-SCENARIO("logging with a FATAL level") {
+SCENARIO("logging with a FATAL level with line numbers") {
     logging_test_context context;
     REQUIRE(LOG_IS_FATAL_ENABLED());
+    int line_num = __LINE__ + 1;
     LOG_FATAL("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "FATAL");
-    REQUIRE(context._appender->_message == string(colorize(log_level::fatal)) + " - testing 1 2 3" + colorize());
-    log("test", log_level::fatal, "testing %1% %2% %3%", 1, "2", 3.0);
+    REQUIRE(context._appender->_message == string(colorize(log_level::fatal)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
+    log("test", log_level::fatal, line_num, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context._appender->_level == "FATAL");
-    REQUIRE(context._appender->_message == string(colorize(log_level::fatal)) + " - testing 1 2 3" + colorize());
+    REQUIRE(context._appender->_message == string(colorize(log_level::fatal)) + ":" + to_string(line_num) + " - testing 1 2 3" + colorize());
     REQUIRE(error_has_been_logged());
 }
 
-SCENARIO("logging with on_message") {
+SCENARIO("logging with on_message with line numbers") {
     logging_test_context context;
     string message;
     log_level level;


### PR DESCRIPTION
Makes logging line numbers a compile-time configuration option that can
be set per-project using the same compiled artifacts of Leatherman. This
is needed to support the `make install` workflow for Leatherman (LTH-1).