### PR TITLE
(LTH-12) Extract facter Windows helpers and wrappers to Leatherman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@ Gemfile.local
 Gemfile.lock
 /nbproject
 compile_commands.json
-/build/
 
 # Generated files
 /debug*/
 /release*/
 /.idea/
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ add_leatherman_dir(locale)
 add_leatherman_dir(logging)
 add_leatherman_dir(rapidjson)
 add_leatherman_dir(json_container)
+add_leatherman_dir(util)
+if(WIN32)
+  add_leatherman_dir(windows)
+endif()
+
 
 list(REVERSE LEATHERMAN_LIBRARIES)
 list(REMOVE_DUPLICATES LEATHERMAN_INCLUDE_DIRS)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ excluded from LEATHERMAN_INCLUDE_DIRS. To use Catch, explicitly add
 
 to the CMakeLists.txt file of your testing directory.
 
+### Using Windows
+
+In order to use the Windows libraries, Logging must be set up.
+
 ## Extending Leatherman
 
 Adding a new library to leatherman is easy!

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(Boost 1.54 REQUIRED)
+
+add_leatherman_includes("${Boost_INCLUDE_DIRS}")
+
+add_leatherman_headers("inc/leatherman")

--- a/util/inc/leatherman/util/scoped_resource.hpp
+++ b/util/inc/leatherman/util/scoped_resource.hpp
@@ -1,0 +1,130 @@
+/**
+ * @file
+ * Declares the base class for scoped resources.
+ */
+#pragma once
+
+#include <functional>
+
+namespace leatherman { namespace util {
+    /**
+     * Simple class that is used for the RAII pattern.
+     * Used to scope a resource.  When it goes out of scope, a deleter
+     * function is called to delete the resource.
+     * This type can be moved but cannot be copied.
+     * @tparam T The type of resource being scoped.
+    */
+    template<typename T>
+    struct scoped_resource
+    {
+        /**
+         * Constructs an uninitialized scoped_resource.
+         * Can be initialized via move assignment.
+         */
+        scoped_resource() :
+            _resource(),
+            _deleter(nullptr)
+        {
+        }
+
+        /**
+         * Constructs a scoped_resource.
+         * Takes ownership of the given resource.
+         * @param resource The resource to scope.
+         * @param deleter The function to call when the resource goes out of scope.
+         */
+        scoped_resource(T resource, std::function<void(T&)> deleter) :
+            _resource(std::move(resource)),
+            _deleter(deleter)
+        {
+        }
+
+        /**
+         * Prevents the scoped_resource from being copied.
+         */
+        explicit scoped_resource(scoped_resource<T> const&) = delete;
+        /**
+         * Prevents the scoped_resource from being copied.
+         * @returns Returns this scoped_resource.
+         */
+        scoped_resource& operator=(scoped_resource<T> const&) = delete;
+        /**
+         * Moves the given scoped_resource into this scoped_resource.
+         * @param other The scoped_resource to move into this scoped_resource.
+         */
+        scoped_resource(scoped_resource<T>&& other)
+        {
+            *this = std::move(other);
+        }
+
+        /**
+         * Moves the given scoped_resource into this scoped_resource.
+         * @param other The scoped_resource to move into this scoped_resource.
+         * @return Returns this scoped_resource.
+         */
+        scoped_resource& operator=(scoped_resource<T>&& other)
+        {
+            release();
+            _resource = std::move(other._resource);
+            _deleter = std::move(other._deleter);
+
+            // Ensure the deleter is in a known "empty" state; we can't rely on default move semantics for that
+            other._deleter = nullptr;
+            return *this;
+        }
+
+        /**
+         * Destructs a scoped_resource.
+         */
+        ~scoped_resource()
+        {
+            release();
+        }
+
+        /**
+         * Implicitly casts to T&.
+         * @return Returns reference-to-T.
+         */
+        operator T&()
+        {
+            return _resource;
+        }
+
+        /**
+         * Implicitly casts to T const&.
+         * @return Returns const-reference-to-T.
+         */
+        operator T const&() const
+        {
+            return _resource;
+        }
+
+        /**
+         * Releases the resource before destruction.
+         */
+        void release()
+        {
+            if (_deleter) {
+                _deleter(_resource);
+                _deleter = std::function<void(T&)>();
+            }
+        }
+
+     protected:
+        /**
+         * Stores the resource being scoped.
+         */
+        T _resource;
+        /**
+         * Stores the function to call when the resource goes out of scope.
+         */
+        std::function<void(T&)> _deleter;
+
+     private:
+        void* operator new(size_t) = delete;
+        void operator delete(void*) = delete;
+        void* operator new[](size_t) = delete;
+        void operator delete[](void* ptr) = delete;
+    };
+
+}}  // namespace leatherman::util

--- a/util/inc/leatherman/util/strings.hpp
+++ b/util/inc/leatherman/util/strings.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * Declares utility functions for dealing with strings.
+ */
+#pragma once
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/compare.hpp>
+#include <string>
+
+namespace leatherman { namespace util {
+
+        /**
+         * Case-insensitive string comparison.
+         */
+        struct ciless : std::binary_function<std::string, std::string, bool>
+        {
+            /**
+             * Compares two strings for a "less than" relationship using a case-insensitive comparison.
+             * @param s1 The first string to compare.
+             * @param s2 The second string to compare.
+             * @return Returns true if s1 is less than s2 or false if s1 is equal to or greater than s2.
+             */
+            bool operator() (const std::string &s1, const std::string &s2) const {
+                return boost::lexicographical_compare(s1, s2, boost::is_iless());
+            }
+        };
+}}  // namespace leatherman::util
+

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_package(Boost 1.54 REQUIRED)
+
+add_leatherman_includes("${Boost_INCLUDE_DIRS}")
+
+leatherman_dependency(nowide)
+leatherman_dependency(logging)
+leatherman_dependency(util)
+
+if (BUILDING_LEATHERMAN)
+    leatherman_logging_namespace("leatherman.logging")
+    leatherman_logging_line_numbers()
+endif()
+
+set(WINDOWS_UTIL_SOURCES
+  "src/registry.cc"
+  "src/process.cc"
+  "src/user.cc"
+  "src/wmi.cc"
+  "src/system_error.cc"
+)
+
+add_leatherman_library(${WINDOWS_UTIL_SOURCES})
+add_leatherman_headers(inc/leatherman)
+
+target_link_libraries(leatherman_windows 
+	Wbemuuid.lib
+	userenv.lib
+)

--- a/windows/inc/leatherman/windows/process.hpp
+++ b/windows/inc/leatherman/windows/process.hpp
@@ -1,0 +1,22 @@
+/**
+ * @file
+ * Declares utility functions for querying process properties
+ */
+#pragma once
+
+namespace leatherman { namespace windows { namespace process {
+
+    /**
+     * Returns whether or not the OS has the ability to set elevated token information.
+     * @return True on Windows Vista or later, otherwise false.
+     */
+    bool supports_elevated_security();
+
+    /**
+     * Returns whether or not the owner of the current process is running with elevated security privileges.
+     * Only supported on Windows Vista or later.
+     * @return True if elevated, otherwise false.
+     */
+    bool has_elevated_security();
+
+}}}  // namespace leatherman::windows::process

--- a/windows/inc/leatherman/windows/registry.hpp
+++ b/windows/inc/leatherman/windows/registry.hpp
@@ -1,0 +1,56 @@
+/**
+ * @file
+ * Declares utility functions for interacting with the Windows registry.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+#include <stdexcept>
+
+namespace leatherman { namespace windows {
+
+    /**
+     * Exception thrown when registry lookupfails.
+     */
+    struct registry_exception : std::runtime_error
+    {
+        /**
+         * Constructs a registry_exception.
+         * @param message The exception message.
+         */
+        explicit registry_exception(std::string const& message);
+    };
+
+    namespace registry {
+        /**
+         * HKEY Classes, derived from
+         * http://msdn.microsoft.com/en-us/library/windows/desktop/ms724868(v=vs.85).aspxs
+         */
+        enum class HKEY {
+            CLASSES_ROOT, CURRENT_CONFIG, CURRENT_USER, LOCAL_MACHINE,
+            PERFORMANCE_DATA, PERFORMANCE_NLSTEXT, PERFORMANCE_TEXT, USERS
+        };
+
+        /**
+         * Retrieve a string value from the registry.
+         * @param hkey The registry key handle.
+         * @param subkey The name of the registry key.
+         * @param value The name of the registry value.
+         * @return A string value corresponding to a REG_SZ or REG_EXPAND_SZ type.
+         *         Returns an empty string if the value doesn't exist or isn't a string type.
+         */
+        std::string get_registry_string(HKEY hkey, std::string const& subkey, std::string const& value);
+
+        /**
+         * Retrieve a vector of string values from the registry.
+         * @param hkey The registry key handle.
+         * @param subkey The name of the registry key.
+         * @param value The name of the registry value.
+         * @return An array of string values corresponding to the REG_MULTI_SZ type.
+         *         Returns an empty vector if the value doesn't exist or isn't a composite string type.
+         */
+        std::vector<std::string> get_registry_strings(HKEY hkey, std::string const& subkey, std::string const& value);
+    }
+
+}}  // namespace leatherman::windows

--- a/windows/inc/leatherman/windows/system_error.hpp
+++ b/windows/inc/leatherman/windows/system_error.hpp
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Declares utility functions for getting Windows error messages.
+ */
+#pragma once
+
+#include <string>
+
+namespace leatherman { namespace windows {
+    /**
+     * This is a wrapper for printing error messages on Windows.
+     * @param err The Windows error code.
+     * @return A formatted string "<error_message> (<error_code>)".
+     */
+    std::string system_error(unsigned long err);
+
+    /**
+     * This is a wrapper for printing error messages on Windows.
+     * It calls system_error with GetLastError as the argument.
+     * @return A formatted string "<error_message> (<error_code>)".
+     */
+    std::string system_error();
+}}  // namespace leatherman::windows

--- a/windows/inc/leatherman/windows/user.hpp
+++ b/windows/inc/leatherman/windows/user.hpp
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Declares utility functions for querying user properties
+ */
+#pragma once
+
+#include <string>
+
+namespace leatherman { namespace windows { namespace user {
+
+    /**
+     * Determines whether the current process has Administrator privileges and can be expected to succeed at
+     * tasks restricted to Administrators.
+     * @return True if the current process has Administrator privileges, otherwise false.
+     */
+    bool is_admin();
+
+    /**
+     * Query token membership to determine whether the current user is a member of the Administrators group.
+     * @return True if user is an Administrator, otherwise false.
+     */
+    bool check_token_membership();
+
+    /**
+     * Finds the user's home directory in a Ruby-compatible way.
+     * @return The home directory, trying %HOME% > %HOMEDRIVE%%HOMEPATH% > %USERPROFILE%
+     */
+    std::string home_dir();
+
+}}}  // namespace leatherman::windows::user

--- a/windows/inc/leatherman/windows/windows.hpp
+++ b/windows/inc/leatherman/windows/windows.hpp
@@ -1,0 +1,10 @@
+/**
+ * @file
+ * Utility header for including Windows API headers.
+ */
+#pragma once
+
+// Windows has several header files with fixed dependency ordering. Include interdependent headers here,
+// and anywhere we need include this header.
+#include <winsock2.h>
+#include <windows.h>

--- a/windows/inc/leatherman/windows/wmi.hpp
+++ b/windows/inc/leatherman/windows/wmi.hpp
@@ -1,0 +1,188 @@
+/**
+ * @file
+ * Declares utility functions for interacting with Windows Management Instrumentation.
+ */
+#pragma once
+
+#include <leatherman/util/scoped_resource.hpp>
+#include <leatherman/util/strings.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <string>
+#include <map>
+#include <vector>
+
+// Forward declarations
+class IWbemLocator;
+class IWbemServices;
+
+namespace leatherman { namespace windows {
+
+    /**
+     * Exception thrown when wmi initialization fails.
+     */
+    struct wmi_exception : std::runtime_error
+    {
+        /**
+         * Constructs a wmi_exception.
+         * @param message The exception message.
+         */
+        explicit wmi_exception(std::string const& message);
+    };
+
+    /**
+     * A class for initiating a WMI connection over COM and querying it.
+     */
+    struct wmi {
+        /**
+         * Identifier for the WMI class Win32_ComputerSystem
+         */
+        constexpr static char const* computersystem = "Win32_ComputerSystem";
+
+        /**
+         * Identifier for the WMI class Win32_ComputerSystemProduct
+         */
+        constexpr static char const* computersystemproduct = "Win32_ComputerSystemProduct";
+
+        /**
+         * Identifier for the WMI class Win32_OperatingSystem
+         */
+        constexpr static char const* operatingsystem = "Win32_OperatingSystem";
+
+        /**
+         * Identifier for the WMI class Win32_BIOS
+         */
+        constexpr static char const* bios = "Win32_Bios";
+
+        /**
+         * Identifier for the WMI class Win32_Processor
+         */
+        constexpr static char const* processor = "Win32_Processor";
+
+        /**
+         * Identifier for the WMI property Architecture
+         */
+        constexpr static char const* architecture = "Architecture";
+
+        /**
+         * Identifier for the WMI property Name
+         */
+        constexpr static char const* name = "Name";
+
+        /**
+         * Identifier for the WMI property Manufacturer
+         */
+        constexpr static char const* manufacturer = "Manufacturer";
+
+        /**
+         * Identifier for the WMI property Model
+         */
+        constexpr static char const* model = "Model";
+
+        /**
+         * Identifier for the WMI property SerialNumber
+         */
+        constexpr static char const* serialnumber = "SerialNumber";
+
+        /**
+         * Identifier for the WMI property NumberOfLogicalProcessors
+         */
+        constexpr static char const* numberoflogicalprocessors = "NumberOfLogicalProcessors";
+
+        /**
+         * Identifier for the WMI property LastBootUpTime
+         */
+        constexpr static char const* lastbootuptime = "LastBootUpTime";
+
+        /**
+         * Identifier for the WMI property LocalDateTime
+         */
+        constexpr static char const* localdatetime = "LocalDateTime";
+
+        /**
+         * Identifier for the WMI property ProductType
+         */
+        constexpr static char const* producttype = "ProductType";
+
+        /**
+         * Identifier for the WMI property OtherTypeDescription
+         */
+        constexpr static char const* othertypedescription = "OtherTypeDescription";
+
+        /**
+         * Multi-map with case-insensitive lookup.
+         */
+        using imap = std::multimap<std::string, std::string, util::ciless>;
+
+        /**
+         * Vector of case-insensitive multi-maps.
+         */
+        using imaps = std::vector<imap>;
+
+        /**
+         * Range of values for an array type.
+         */
+        using kv_range = boost::iterator_range<imap::const_iterator>;
+
+        /**
+         * Initializes a COM connection for WMI queries. Throws a wmi_exception on failure.
+         */
+        wmi();
+
+        /**
+         * This is a utility for querying WMI classes. Windows queries are case-insensitive,
+         * so the returned keys aren't guaranteed to have the same case as the arguments.
+         * Returns a vector of case-insensitive maps so the argument keys can safely be used for lookup.
+         * Some groups can return multiple objects; in that case the returned vector will
+         * have a multi-map for each object. If a property returns an array, it will have
+         * multiple entries in the multimap.
+         * @param group The class alias to query
+         * @param keys A list of keys to query from the specified class
+         * @param extra Extra arguments to the WMI query, such as filters
+         * @return A vector of case-insensitive maps of the keys argument and their corresponding values
+         */
+        imaps query(std::string const& group, std::vector<std::string> const& keys, std::string const& extra = "") const;
+
+        /**
+         * A utility for retrieving a single entry from an imap. It should only be used if
+         * it's known that the requested property is not an array.
+         * To retrieve an array, use imap's equal_range.
+         * @param kvmap A case-insensitive multimap of keys and their values.
+         * @param key The key to lookup.
+         * @return Return the value matching the specified key.
+         */
+        static std::string const& get(imap const& kvmap, std::string const& key);
+
+        /**
+         * A utility for retrieving an array entry from an imap. If only one value exists
+         * it returns a range of one element.
+         * @param kvmap A case-insensitive multimap of keys and their values.
+         * @param key The key to lookup.
+         * @return An iterator range of key-value pairs matching the specified key.
+         */
+        static kv_range get_range(imap const& kvmap, std::string const& key);
+
+        /**
+         * A utility for retrieving a single entry from an imaps. It should only be used if
+         * it's known that the requested group will only return a single object.
+         * @param kvmaps A vector of case-insensitive multimap of keys and their values.
+         * @param key The key to lookup.
+         * @return Return the value matching the specified key.
+         */
+        static std::string const& get(imaps const& kvmaps, std::string const& key);
+
+        /**
+         * A utility for retrieving an array entry from an imaps. It should only be used if
+         * it's known that the requested group will only return a single object.
+         * @param kvmaps A vector of case-insensitive multimap of keys and their values.
+         * @param key The key to lookup.
+         * @return An iterator range of key-value pairs matching the specified key.
+         */
+        static kv_range get_range(imaps const& kvmaps, std::string const& key);
+
+     private:
+        util::scoped_resource<bool> _coInit;
+        util::scoped_resource<IWbemLocator *> _pLoc;
+        util::scoped_resource<IWbemServices *> _pSvc;
+    };
+
+}}  // namespace leatherman::windows

--- a/windows/src/process.cc
+++ b/windows/src/process.cc
@@ -1,0 +1,42 @@
+#include <leatherman/windows/system_error.hpp>
+#include <leatherman/windows/windows.hpp>
+#include <leatherman/util/scoped_resource.hpp>
+#include <leatherman/logging/logging.hpp>
+
+using namespace std;
+
+namespace leatherman { namespace windows { namespace process {
+
+    bool supports_elevated_security()
+    {
+        // In the future this can use IsWindowsVistaOrGreater, but as of the initial work versionhelpers.h is only in
+        // the master branch of MinGW-w64.
+        OSVERSIONINFOEXW vi = {sizeof(vi), HIBYTE(_WIN32_WINNT_VISTA), LOBYTE(_WIN32_WINNT_VISTA), 0, 0, {0}, 0};
+
+        return VerifyVersionInfoW(&vi, VER_MAJORVERSION|VER_MINORVERSION|VER_SERVICEPACKMAJOR,
+            VerSetConditionMask(VerSetConditionMask(VerSetConditionMask(0,
+                VER_MAJORVERSION, VER_GREATER_EQUAL),
+                VER_MINORVERSION, VER_GREATER_EQUAL),
+                VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL));
+    }
+
+    bool has_elevated_security()
+    {
+        HANDLE temp_token = INVALID_HANDLE_VALUE;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &temp_token)) {
+            LOG_DEBUG("OpenProcessToken call failed: %1%", system_error());
+            return false;
+        }
+        util::scoped_resource<HANDLE> token(temp_token, CloseHandle);
+
+        TOKEN_ELEVATION token_elevation;
+        DWORD token_elevation_length;
+        if (!GetTokenInformation(token, TokenElevation, &token_elevation, sizeof(TOKEN_ELEVATION), &token_elevation_length)) {
+            LOG_DEBUG("GetTokenInformation call failed: %1%", system_error());
+            return false;
+        }
+
+        return token_elevation.TokenIsElevated;
+    }
+
+}}}  // namespace leatherman::windows::process

--- a/windows/src/registry.cc
+++ b/windows/src/registry.cc
@@ -1,0 +1,93 @@
+#include <leatherman/windows/registry.hpp>
+#include <leatherman/windows/system_error.hpp>
+#include <leatherman/windows/windows.hpp>
+#include <boost/format.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/nowide/convert.hpp>
+
+using namespace std;
+
+namespace leatherman { namespace windows {
+
+    registry_exception::registry_exception(string const& message) :
+        runtime_error(message)
+    {
+    }
+
+    static HKEY get_hkey(registry::HKEY hkey)
+    {
+        switch (hkey) {
+            case registry::HKEY::CLASSES_ROOT:        return HKEY_CLASSES_ROOT;
+            case registry::HKEY::CURRENT_CONFIG:      return HKEY_CURRENT_CONFIG;
+            case registry::HKEY::CURRENT_USER:        return HKEY_CURRENT_USER;
+            case registry::HKEY::LOCAL_MACHINE:       return HKEY_LOCAL_MACHINE;
+            case registry::HKEY::PERFORMANCE_DATA:    return HKEY_PERFORMANCE_DATA;
+            case registry::HKEY::PERFORMANCE_NLSTEXT: return HKEY_PERFORMANCE_NLSTEXT;
+            case registry::HKEY::PERFORMANCE_TEXT:    return HKEY_PERFORMANCE_TEXT;
+            case registry::HKEY::USERS:               return HKEY_USERS;
+            default:
+                throw registry_exception("invalid HKEY specified");
+        }
+    }
+
+    // Returns the registry value as a wstring buffer. It's up to the caller to interpret it.
+    // This only really works for RRF_RT_REG_EXPAND_SZ, RRF_RT_REG_MULTI_SZ, and RRF_RT_REG_SZ.
+    static wstring get_regvalue(registry::HKEY hkey, string const& lpSubKey, string const& lpValue, DWORD flags)
+    {
+        auto hk = get_hkey(hkey);
+        auto lpSubKeyW = boost::nowide::widen(lpSubKey);
+        auto lpValueW = boost::nowide::widen(lpValue);
+
+        DWORD size = 0u;
+        auto err = RegGetValueW(hk, lpSubKeyW.c_str(), lpValueW.c_str(), flags, nullptr, nullptr, &size);
+        if (err != ERROR_SUCCESS) {
+            throw registry_exception(str(boost::format("error reading registry key %1% %2%: %3%") %
+                lpSubKey % lpValue % system_error(err)));
+        }
+
+        // Size is the number of bytes needed.
+        wstring buffer((size*sizeof(char))/sizeof(wchar_t), '\0');
+        err = RegGetValueW(hk, lpSubKeyW.c_str(), lpValueW.c_str(), flags, nullptr, &buffer[0], &size);
+        if (err != ERROR_SUCCESS) {
+            throw registry_exception(str(boost::format("error reading registry key %1% %2%: %3%") %
+                lpSubKey % lpValue % system_error(err)));
+        }
+
+        // Size now represents bytes copied (which can be less than we allocated). Resize, and also remove the
+        // extraneous null-terminator from RegGetValueW (wstring handles termination internally).
+        auto numwchars = (size*sizeof(char))/sizeof(wchar_t);
+        buffer.resize(numwchars > 0u ? numwchars - 1u : 0u);
+
+        return buffer;
+    }
+
+    string registry::get_registry_string(registry::HKEY hkey, string const& subkey, string const& value)
+    {
+        // From http://msdn.microsoft.com/en-us/library/windows/desktop/ms724868(v=vs.85).aspx
+        // "RRF_RT_REG_SZV automatically converts REG_EXPAND_SZ to REG_SZ unless RRF_NOEXPAND is specified."
+        // This seems like the desired behavior most of the time.
+        return boost::nowide::narrow(get_regvalue(hkey, subkey, value, RRF_RT_REG_SZ));
+    }
+
+    vector<string> registry::get_registry_strings(registry::HKEY hkey, string const& subkey, string const& value)
+    {
+        auto buffer = get_regvalue(hkey, subkey, value, RRF_RT_REG_MULTI_SZ);
+
+        vector<string> strings;
+
+        wstring accum;
+        for (auto c : buffer) {
+            if (c == L'\0') {
+                string val = boost::trim_copy(boost::nowide::narrow(accum));
+                if (!val.empty()) {
+                    strings.emplace_back(move(val));
+                }
+                accum.clear();
+            } else {
+                accum += c;
+            }
+        }
+        return strings;
+    }
+
+}}  // namespace leatherman::windows

--- a/windows/src/system_error.cc
+++ b/windows/src/system_error.cc
@@ -1,0 +1,30 @@
+#include <leatherman/util/scoped_resource.hpp>
+#include <leatherman/windows/system_error.hpp>
+#include <leatherman/windows/windows.hpp>
+#include <boost/format.hpp>
+#include <boost/nowide/convert.hpp>
+
+using namespace std;
+
+namespace leatherman { namespace windows {
+
+    string system_error(DWORD err)
+    {
+        LPWSTR buffer = nullptr;
+        if (FormatMessageW(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+            nullptr, err, 0, reinterpret_cast<LPWSTR>(&buffer), 0, nullptr) == 0 || !buffer) {
+            return (boost::format("unknown error (%1%)") % err).str();
+        }
+
+        // boost format could throw, so ensure the buffer is freed.
+        util::scoped_resource<LPWSTR> guard(buffer, [](LPWSTR ptr) { if (ptr) LocalFree(ptr); });
+        return (boost::format("%1% (%2%)") % boost::nowide::narrow(buffer) % err).str();
+    }
+
+    string system_error()
+    {
+        return system_error(GetLastError());
+    }
+
+}}  // namespace leatherman::windows

--- a/windows/src/user.cc
+++ b/windows/src/user.cc
@@ -1,0 +1,76 @@
+#include <leatherman/windows/user.hpp>
+#include <leatherman/windows/process.hpp>
+#include <leatherman/windows/system_error.hpp>
+#include <leatherman/windows/windows.hpp>
+#include <leatherman/util/scoped_resource.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <boost/nowide/convert.hpp>
+#include <userenv.h>
+
+using namespace std;
+
+namespace leatherman { namespace windows { namespace user {
+
+    bool is_admin()
+    {
+        if (process::supports_elevated_security()) {
+            return process::has_elevated_security();
+        }
+
+        return check_token_membership();
+    }
+
+    bool check_token_membership()
+    {
+        DWORD sid_size = SECURITY_MAX_SID_SIZE;
+        unsigned char sid_buffer[SECURITY_MAX_SID_SIZE];
+        auto sid = static_cast<PSID>(&sid_buffer);
+        if (!CreateWellKnownSid(WinBuiltinAdministratorsSid, nullptr, sid, &sid_size)) {
+            LOG_DEBUG("Failed to create administrators SID: %1%", system_error());
+            return false;
+        }
+
+        if (!IsValidSid(sid)) {
+            LOG_DEBUG("Invalid SID");
+            return false;
+        }
+
+        BOOL is_member;
+        if (!CheckTokenMembership(nullptr, sid, &is_member)) {
+            LOG_DEBUG("Failed to check membership: %1%", system_error());
+            return false;
+        }
+
+        return is_member;
+    }
+
+    string home_dir() {
+        HANDLE temp_token = INVALID_HANDLE_VALUE;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &temp_token)) {
+            LOG_DEBUG("OpenProcessToken call failed: %1%", system_error());
+            return {};
+        }
+        util::scoped_resource <HANDLE> token(temp_token, CloseHandle);
+
+        DWORD pathLen = 0u;
+        if (GetUserProfileDirectoryW(token, nullptr, &pathLen)) {
+            LOG_DEBUG("GetUserProfileDirectoryW call returned unexpectedly");
+            return {};
+        } else if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+            LOG_DEBUG("GetUserProfileDirectoryW call failed: %1%", system_error());
+            return {};
+        }
+
+        wstring buffer(pathLen, '\0');
+        if (!GetUserProfileDirectoryW(token, &buffer[0], &pathLen)) {
+            LOG_DEBUG("GetUserProfileDirectoryW call failed: %1%", system_error());
+            return {};
+        }
+
+        // Strip the trailing null character.
+        buffer.resize(pathLen > 0u ? pathLen - 1u : 0u);
+        return boost::nowide::narrow(buffer);
+    }
+
+}}}  // namespace leatherman::windows::user
+

--- a/windows/src/wmi.cc
+++ b/windows/src/wmi.cc
@@ -1,0 +1,191 @@
+#include <leatherman/util/strings.hpp>
+#include <leatherman/windows/wmi.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/nowide/convert.hpp>
+
+#define _WIN32_DCOM
+#include <comdef.h>
+#include <wbemidl.h>
+
+using namespace std;
+
+namespace leatherman { namespace windows {
+
+    wmi_exception::wmi_exception(string const& message) :
+        runtime_error(message)
+    {
+    }
+
+    string format_hresult(char const* s, HRESULT hres)
+    {
+        return str(boost::format("%1% (%2%)") % s % boost::io::group(hex, showbase, hres));
+    }
+
+    // GUID taken from a Windows installation and unaccepted change to MinGW-w64. The MinGW-w64 library
+    // doesn't define it, but obscures the Windows Platform SDK version of wbemuuid.lib.
+    constexpr static CLSID MyCLSID_WbemLocator = {0x4590f811, 0x1d3a, 0x11d0, 0x89, 0x1f, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24};
+
+    wmi::wmi()
+    {
+        LOG_DEBUG("initializing WMI");
+        auto hres = CoInitializeEx(0, COINIT_MULTITHREADED);
+        if (FAILED(hres)) {
+            if (hres == RPC_E_CHANGED_MODE) {
+                LOG_DEBUG("using prior COM concurrency model");
+            } else {
+                throw wmi_exception(format_hresult("failed to initialize COM library", hres));
+            }
+        } else {
+            _coInit = util::scoped_resource<bool>(true, [](bool b) { CoUninitialize(); });
+        }
+
+        IWbemLocator *pLoc;
+        hres = CoCreateInstance(MyCLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator,
+            reinterpret_cast<LPVOID *>(&pLoc));
+        if (FAILED(hres)) {
+            throw wmi_exception(format_hresult("failed to create IWbemLocator object", hres));
+        }
+        _pLoc = util::scoped_resource<IWbemLocator *>(pLoc,
+            [](IWbemLocator *loc) { if (loc) loc->Release(); });
+
+        IWbemServices *pSvc;
+        hres = (*_pLoc).ConnectServer(_bstr_t(L"ROOT\\CIMV2"), nullptr, nullptr, nullptr, 0, nullptr, nullptr, &pSvc);
+        if (FAILED(hres)) {
+            throw wmi_exception(format_hresult("could not connect to WMI server", hres));
+        }
+        _pSvc = util::scoped_resource<IWbemServices *>(pSvc,
+            [](IWbemServices *svc) { if (svc) svc->Release(); });
+
+        hres = CoSetProxyBlanket(_pSvc, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, NULL,
+            RPC_C_AUTHN_LEVEL_CALL, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_NONE);
+        if (FAILED(hres)) {
+            throw wmi_exception(format_hresult("could not set proxy blanket", hres));
+        }
+    }
+
+    static void wmi_add_result(wmi::imap &vals, string const& group, string const& s, VARIANT *vtProp)
+    {
+        if (V_VT(vtProp) == (VT_ARRAY | VT_BSTR)) {
+            // It's an array of elements; serialize the array as elements with the same key in the imap.
+            // To keep this simple, ignore multi-dimensional arrays.
+            SAFEARRAY *arr = V_ARRAY(vtProp);
+            if (arr->cDims != 1) {
+                LOG_DEBUG("ignoring %1%-dimensional array in query %2%.%3%", arr->cDims, group, s);
+                return;
+            }
+
+            BSTR *pbstr;
+            if (FAILED(SafeArrayAccessData(arr, reinterpret_cast<void **>(&pbstr)))) {
+                return;
+            }
+
+            for (auto i = 0u; i < arr->rgsabound[0].cElements; ++i) {
+                vals.emplace(s, boost::trim_copy(boost::nowide::narrow(pbstr[i])));
+            }
+            SafeArrayUnaccessData(arr);
+        } else if (FAILED(VariantChangeType(vtProp, vtProp, 0, VT_BSTR)) || V_VT(vtProp) != VT_BSTR) {
+            // Uninitialized (null) values can just be ignored. Any others get reported.
+            if (V_VT(vtProp) != VT_NULL) {
+                LOG_DEBUG("WMI query %1%.%2% result could not be converted from type %3% to a string", group, s, V_VT(vtProp));
+            }
+        } else {
+            vals.emplace(s, boost::trim_copy(boost::nowide::narrow(V_BSTR(vtProp))));
+        }
+    }
+
+    wmi::imaps wmi::query(string const& group, vector<string> const& keys, string const& extended) const
+    {
+        IEnumWbemClassObject *_pEnum = NULL;
+        string qry = "SELECT " + boost::join(keys, ",") + " FROM " + group;
+        if (!extended.empty()) {
+            qry += " " + extended;
+        }
+
+        auto hres = (*_pSvc).ExecQuery(_bstr_t(L"WQL"), _bstr_t(boost::nowide::widen(qry).c_str()),
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, NULL, &_pEnum);
+        if (FAILED(hres)) {
+            LOG_DEBUG("query %1% failed", qry);
+            return {};
+        }
+        util::scoped_resource<IEnumWbemClassObject *> pEnum(_pEnum,
+            [](IEnumWbemClassObject *rsc) { if (rsc) rsc->Release(); });
+
+        imaps array_of_vals;
+
+        IWbemClassObject *pclsObjs[256];
+        ULONG uReturn = 0;
+        while (pEnum) {
+            auto hr = (*pEnum).Next(WBEM_INFINITE, 256, pclsObjs, &uReturn);
+            if (FAILED(hr) || 0 == uReturn) {
+                break;
+            }
+
+            for (auto pclsObj : boost::make_iterator_range(pclsObjs, pclsObjs+uReturn)) {
+                imap vals;
+                for (auto &s : keys) {
+                    VARIANT vtProp;
+                    CIMTYPE vtType;
+                    hr = pclsObj->Get(_bstr_t(boost::nowide::widen(s).c_str()), 0, &vtProp, &vtType, 0);
+                    if (FAILED(hr)) {
+                        LOG_DEBUG("query %1%.%2% could not be found", group, s);
+                        break;
+                    }
+
+                    wmi_add_result(vals, group, s, &vtProp);
+                    VariantClear(&vtProp);
+                }
+                pclsObj->Release();
+                array_of_vals.emplace_back(move(vals));
+            }
+        }
+
+        return array_of_vals;
+    }
+
+    string const& wmi::get(wmi::imap const& kvmap, string const& key)
+    {
+        static const string empty = {};
+        auto valIt = kvmap.find(key);
+        if (valIt == kvmap.end()) {
+            return empty;
+        } else {
+            if (kvmap.count(key) > 1) {
+                LOG_DEBUG("only single value requested from array for key %1%", key);
+            }
+            return valIt->second;
+        }
+    }
+
+    wmi::kv_range wmi::get_range(wmi::imap const& kvmap, string const& key)
+    {
+        return kv_range(kvmap.equal_range(key));
+    }
+
+    string const& wmi::get(wmi::imaps const& kvmaps, string const& key)
+    {
+        if (kvmaps.size() > 0) {
+            if (kvmaps.size() > 1) {
+                LOG_DEBUG("only single entry requested from array of entries for key %1%", key);
+            }
+            return get(kvmaps[0], key);
+        } else {
+            throw wmi_exception("unable to get from empty array of objects");
+        }
+    }
+
+    wmi::kv_range wmi::get_range(wmi::imaps const& kvmaps, string const& key)
+    {
+        if (kvmaps.size() > 0) {
+            if (kvmaps.size() > 1) {
+                LOG_DEBUG("only single entry requested from array of entries for key %1%", key);
+            }
+            return get_range(kvmaps[0], key);
+        } else {
+            throw wmi_exception("unable to get_range from empty array of objects");
+        }
+    }
+
+}}  // namespace leatherman::windows


### PR DESCRIPTION
Move the registry, user, process, system_error, and wmi Windows helper classes from facter to Leatherman, creating a Windows utility library for use in other projects.