### PR TITLE
(maint) Fix compiling logging tests with Clang

### DIFF
--- a/logging/tests/logging.cc
+++ b/logging/tests/logging.cc
@@ -1,17 +1,21 @@
 #include "logging.hpp"
 #include <boost/nowide/iostream.hpp>
 
-namespace leatherman { namespace test {
+namespace boost {
 
-    bool operator== (boost::regex const& lhs, string const& rhs)
+    bool operator== (boost::regex const& lhs, std::string const& rhs)
     {
         return boost::regex_match(rhs, lhs);
     }
 
-    bool operator== (string const& lhs, boost::regex const& rhs)
+    bool operator== (std::string const& lhs, boost::regex const& rhs)
     {
         return boost::regex_match(lhs, rhs);
     }
+
+}  // namespace boost
+
+namespace leatherman { namespace test {
 
     std::streamsize colored_tokenizing_stringbuf::xsputn(char_type const* s, std::streamsize count)
     {

--- a/logging/tests/logging.cc
+++ b/logging/tests/logging.cc
@@ -1,4 +1,5 @@
 #include "logging.hpp"
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/nowide/iostream.hpp>
 
 namespace boost {
@@ -17,9 +18,21 @@ namespace boost {
 
 namespace leatherman { namespace test {
 
+    static bool all_spaces(string const& s)
+    {
+        return boost::algorithm::all(s, [](char c) { return c == ' '; });
+    }
+
     std::streamsize colored_tokenizing_stringbuf::xsputn(char_type const* s, std::streamsize count)
     {
-        tokens.emplace_back(s, count);
+        auto str = string(s, count);
+        if (all_spaces(str) && !tokens.empty() && all_spaces(tokens.back())) {
+            // Lump all white space strings together.
+            tokens.back() += move(str);
+        } else {
+            tokens.emplace_back(move(str));
+        }
+
         return stringbuf::xsputn(s, count);
     }
 
@@ -40,7 +53,7 @@ namespace leatherman { namespace test {
         static const boost::regex rdate("\\d{4}-\\d{2}-\\d{2}");
         static const boost::regex rtime("[0-2]\\d:[0-5]\\d:\\d{2}\\.\\d{6}");
 
-        _expected = {rdate, R(" "), rtime, R(" "), R(lvl_str.str()), R(" "), R(ns, R::literal)};
+        _expected = {rdate, R(" "), rtime, R(" "), R(lvl_str.str()), R("[ ]+"), R(ns, R::literal)};
 
         if (line_num > 0) {
             _expected.emplace_back(":");

--- a/logging/tests/logging.hpp
+++ b/logging/tests/logging.hpp
@@ -8,6 +8,14 @@
 #include <boost/iterator/zip_iterator.hpp>
 #include <boost/range.hpp>
 
+namespace boost {
+    /**
+     * Regex comparison, so catch can print pretty failure messages
+     */
+    bool operator== (boost::regex const& lhs, std::string const& rhs);
+    bool operator== (std::string const& lhs, boost::regex const& rhs);
+}  // namespace boost
+
 namespace leatherman { namespace test {
     using namespace std;
     using namespace leatherman::logging;
@@ -20,12 +28,6 @@ namespace leatherman { namespace test {
     constexpr char yellow[] = "\33[0;33m";
     constexpr char red[] = "\33[0;31m";
     constexpr char reset[] = "\33[0m";
-
-    /**
-     * Regex comparison, so catch can print pretty failure messages
-     */
-    bool operator== (boost::regex const& lhs, string const& rhs);
-    bool operator== (string const& lhs, boost::regex const& rhs);
 
     /**
      * Zip view for iterating over multiple containers at once


### PR DESCRIPTION
### (maint) Fix compiling logging tests with Clang
Compiling with clang fails, move operator declarations to the boost
namespace because that seems to work.

I'm not really sure why, seems related to https://en.wikipedia.org/wiki/Argument-dependent_name_lookup.

### (maint) Fix testing in Clang
With GCC, somehow the test worked even though padding should've
introduced multiple spaces. Clang showed the error in the test.

Add handling for multiple spaces following the log level string.