### PR TITLE
(maint) Update appveyor to Boost 1.57

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,19 @@
+version: 0.1.0.{build}
+clone_depth: 10
 install:
-  - ps: Get-Date
   - git submodule update --init --recursive
-  - ps: Get-Date
 
-  - ps: choco install 7zip.commandline -source https://www.myget.org/F/puppetlabs -y
-  - ps: choco install mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs -y
-  - ps: $env:PATH = "C:\tools\mingw64\bin;" + $env:PATH
-  - ps: Get-Date
+  - choco install mingw-w64 -y -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
+  - SET PATH=C:\tools\mingw64\bin;%PATH%
 
-  - ps: (New-Object net.webclient).DownloadFile('https://s3.amazonaws.com/kylo-pl-bucket/boost_1_55_0-x86_64_mingw-w64_4.8.3_posix_seh.7z', "$pwd\boost.7z")
-  - ps: 7za x boost.7z -oC:\tools | FIND /V "ing  "
-  - ps: Get-Date
+  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
+  - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
 
 build_script:
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_55_0-x86_64_mingw-w64_4.8.3_posix_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON .
   - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
   - ps: mingw32-make
-  - ps: Get-Date
 
 test_script:
   - ps: ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }


### PR DESCRIPTION
Updates appveyor to use Boost 1.57, and mirror the Facter config.