### PR TITLE
(maint) Bump cmake requirement to 3.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_install:
   # and g++ 4.8
   - sudo apt-get -y install g++-4.8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-  # grab a pre-built cmake 2.8.12 from s3
-  - wget https://s3.amazonaws.com/kylo-pl-bucket/cmake_install.tar.bz2
-  - tar xjvf cmake_install.tar.bz2 --strip 1 -C $HOME
+  # grab a pre-built cmake 3.2.3
+  - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
+  - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $HOME
   # grab a pre-built cppcheck from s3
   - wget https://s3.amazonaws.com/kylo-pl-bucket/pcre-8.36_install.tar.bz2
   - sudo tar xjvf pcre-8.36_install.tar.bz2 --strip 1 -C /usr/local

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.2.2)
 project(LEATHERMAN)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ install:
   - git submodule update --init --recursive
 
   - choco install mingw-w64 -y -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
+  - choco install cmake -Version 3.2.3 -y
   - SET PATH=C:\tools\mingw64\bin;%PATH%
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"

--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -1,7 +1,7 @@
 # Set compiler-specific flags
 # Each of our project dirs sets CMAKE_CXX_FLAGS based on these. We do
 # not set CMAKE_CXX_FLAGS globally because gtest is not warning-clean.
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "\\w*Clang")
     set(LEATHERMAN_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-tautological-constant-out-of-range-compare")
 
     # Clang warns that 'register' is deprecated; 'register' is used throughout boost, so it can't be an error yet.


### PR DESCRIPTION
Required for Boost 1.5.7, and adds support for specifying a VERSION on
the project macro.