### PR TITLE
(maint) Add pthread dependency for boost.thread

### DIFF
--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(Boost 1.54 REQUIRED COMPONENTS log log_setup thread date_time filesystem system chrono regex)
+find_package(Threads)
 
-add_leatherman_deps(${Boost_LIBRARIES})
+add_leatherman_deps(${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")
 
 leatherman_dependency(nowide)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,7 @@
-find_package(Threads)
-
 include_directories(${LEATHERMAN_CATCH_INCLUDE} ${LEATHERMAN_INCLUDE_DIRS})
 add_executable(leatherman_test main.cc ${LEATHERMAN_TEST_SRCS})
 
-target_link_libraries(leatherman_test ${LEATHERMAN_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(leatherman_test ${LEATHERMAN_LIBRARIES})
 if (COVERALLS)
     target_link_libraries(leatherman_test gcov)
 endif()


### PR DESCRIPTION
Some systems (at least ArchLinux) require pthread to be linked for
Boost.Thread. Add that dependency on Unix systems so other projects will
pick it up.