### PR TITLE
(LTH-18) Extract string and time utility functions to Leatherman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ compile_commands.json
 /release*/
 /.idea/
 /build/
+/linux-build/

--- a/file_util/src/directory.cc
+++ b/file_util/src/directory.cc
@@ -4,6 +4,7 @@
 
 using namespace std;
 using namespace boost::filesystem;
+using namespace leatherman::util;
 
 namespace leatherman { namespace file_util {
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,5 +1,14 @@
-find_package(Boost 1.54 REQUIRED)
+find_package(Boost 1.54 REQUIRED date_time chrono system)
 
+add_leatherman_deps(${Boost_LIBRARIES})
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")
 
 add_leatherman_headers(inc/leatherman)
+
+if(WIN32)
+    set(PLATFORM_SRCS "src/windows/time.cc")
+else()
+    set(PLATFORM_SRCS "src/posix/time.cc")
+endif()
+
+add_leatherman_library(src/strings.cc src/time.cc ${PLATFORM_SRCS})

--- a/util/inc/leatherman/util/regex.hpp
+++ b/util/inc/leatherman/util/regex.hpp
@@ -7,7 +7,7 @@
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 
-namespace leatherman { namespace file_util {
+namespace leatherman { namespace util {
 
     /**
      * Helper function for resolving variadic arguments to re_search.

--- a/util/inc/leatherman/util/strings.hpp
+++ b/util/inc/leatherman/util/strings.hpp
@@ -7,6 +7,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/compare.hpp>
 #include <string>
+#include <vector>
 
 namespace leatherman { namespace util {
 
@@ -25,5 +26,21 @@ namespace leatherman { namespace util {
                 return boost::lexicographical_compare(s1, s2, boost::is_iless());
             }
         };
-}}  // namespace leatherman::util
 
+        /**
+         * @return Returns the "s" string in case of more than one thing,
+         *      an empty string otherwise.
+         */
+        std::string plural(int num_of_things);
+
+        /**
+         * @return Returns the "s" string if vector contains more than one item,
+         *      an empty string otherwise.
+         */
+        template<typename T>
+        std::string plural(std::vector<T> const& things);
+
+        /** @return Returns universally unique identifier string. */
+        std::string get_UUID();
+
+}}  // namespace leatherman::util

--- a/util/inc/leatherman/util/time.hpp
+++ b/util/inc/leatherman/util/time.hpp
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Declares utility functions for dealing with time.
+ */
+#pragma once
+
+#include <string>
+#include <ctime>
+
+namespace leatherman { namespace util {
+
+    /**
+     * Adds the specified expiry_minutes to the current time and returns
+     * the related date time string in UTC format.
+     * @return Returns an empty string in case it fails to allocate the buffer.
+     */
+    std::string get_expiry_datetime(int expiry_minutes = 1);
+
+    /**
+     * Gets the current time in ISO8601 format
+     * @param modifier_in_secords Offset from the current time in seconds
+     * @return Returns the current time plus the modifier
+     */
+    std::string get_ISO8601_time(unsigned int modifier_in_seconds = 0);
+
+    /** @return Returns the current datetime string in the %Y%m%d_%H%M%S format */
+    std::string get_date_time();
+
+    /**
+     * Turns a stored time into a local time with correction for timezones.
+     *  @param stored_time The time to be converted.
+     *  @param result The struct in which to store the local time.
+     */
+    void get_local_time(std::time_t* stored_time, std::tm* result);
+
+}}  // namespace leatherman::util

--- a/util/inc/leatherman/util/timer.hpp
+++ b/util/inc/leatherman/util/timer.hpp
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * Declares a simple timer class.
+ */
+#pragma once
+
+#include <chrono>
+
+namespace leatherman { namespace util {
+
+/**
+ * A simple stopwatch/timer we can use for user feedback.  We use the
+ * std::chrono::steady_clock as we don't want to be affected if the system
+ * clock changed around us (think ntp skew/leapseconds).
+ */
+class Timer {
+  public:
+    Timer() {
+        reset();
+    }
+
+    /** @return Returns the time that has passed since last reset in seconds */
+    double elapsed_seconds() {
+        auto now = std::chrono::steady_clock::now();
+        return std::chrono::duration<double>(now - start_).count();
+    }
+
+    /** Resets the clock. */
+    void reset() {
+        start_ = std::chrono::steady_clock::now();
+    }
+
+  private:
+    std::chrono::time_point<std::chrono::steady_clock> start_;
+};
+
+}}  // namespace leatherman::util

--- a/util/src/posix/time.cc
+++ b/util/src/posix/time.cc
@@ -1,0 +1,9 @@
+#include <leatherman/util/time.hpp>
+
+namespace leatherman { namespace util {
+
+    void get_local_time(std::time_t* stored_time, std::tm* result){
+        localtime_r(stored_time, result);
+    }
+
+}}  // namespace leatherman::util

--- a/util/src/strings.cc
+++ b/util/src/strings.cc
@@ -1,0 +1,23 @@
+#include <leatherman/util/strings.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+
+namespace leatherman { namespace util {
+
+    std::string plural(int num_of_things) {
+        return num_of_things > 1 ? "s" : "";
+    }
+
+    template<>
+    std::string plural<std::string>(std::vector<std::string> const& things) {
+        return plural(things.size());
+    }
+
+    std::string get_UUID() {
+        static boost::uuids::random_generator gen;
+        boost::uuids::uuid uuid = gen();
+        return boost::uuids::to_string(uuid);
+    }
+
+}}  // namespace leatherman::util

--- a/util/src/time.cc
+++ b/util/src/time.cc
@@ -1,0 +1,49 @@
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <leatherman/util/time.hpp>
+
+namespace leatherman { namespace util {
+
+    std::string get_expiry_datetime(int expiry_minutes) {
+        struct std::tm expiry_time_info;
+        std::string expiry_time_buffer(80, '\0');
+
+        // Get current time and add the specified minutes
+        std::time_t expiry_time { time(nullptr) };
+        expiry_time += 60 * expiry_minutes;
+
+        // Get local time structure
+        get_local_time(&expiry_time, &expiry_time_info);
+
+        // Return the formatted string
+        if (strftime(&expiry_time_buffer[0], 80, "%FT%TZ", &expiry_time_info) == 0) {
+            // invalid buffer
+            return "";
+        }
+
+        expiry_time_buffer.resize(strlen(&expiry_time_buffer[0]));
+        return expiry_time_buffer;
+    }
+
+    std::string get_ISO8601_time(unsigned int modifier_in_seconds) {
+        boost::posix_time::ptime t = boost::posix_time::microsec_clock::universal_time()
+                                     + boost::posix_time::seconds(modifier_in_seconds);
+        return boost::posix_time::to_iso_extended_string(t) + "Z";
+    }
+
+    std::string get_date_time() {
+        struct std::tm now_info;
+        std::string now_buffer(80, '\0');
+
+        // Get current time
+        std::time_t now { time(nullptr) };
+
+        // Get local time structure
+        get_local_time(&now, &now_info);
+
+        // Return the formatted string
+        strftime(&now_buffer[0], 80, "%Y%m%d_%H%M%S", &now_info);
+        now_buffer.resize(strlen(&now_buffer[0]));
+        return now_buffer;
+    }
+
+}}  // namespace leatherman::util

--- a/util/src/windows/time.cc
+++ b/util/src/windows/time.cc
@@ -1,0 +1,10 @@
+#include <leatherman/util/time.hpp>
+#include <windows.h>
+
+namespace leatherman { namespace util {
+
+    void get_local_time(std::time_t* stored_time, std::tm* result){
+       localtime_s(result, stored_time);
+    }
+
+}}  // namespace leatherman::util


### PR DESCRIPTION
Extracts and standardizes scattered string and time utility functions from cthun-agent, cthun-client, and pegasus.

Currently, there are no unit tests for these methods in any of the original projects. Do we want some for Leatherman?