### PR TITLE
(maint) export LEATHERMAN_LIBRARIES from LeathermanConfig script

### DIFF
--- a/LeathermanConfig.cmake.in
+++ b/LeathermanConfig.cmake.in
@@ -34,5 +34,7 @@ foreach(component ${Leatherman_FIND_COMPONENTS})
     endif()
 endforeach()
 
+set(LEATHERMAN_LIBRARIES ${LEATHERMAN_LIBS} ${LEATHERMAN_DEPS})
+
 list(REMOVE_DUPLICATES LEATHERMAN_INCLUDE_DIRS)
 set(LEATHERMAN_MODULE_DIR "${current_directory}/cmake")


### PR DESCRIPTION
We switched the vendor workflow to use LEATHERMAN_LIBRARIES but did
not update the script for using an installed leatherman.