### PR TITLE
(maint) Merge FACT-1082 fix to wmi

### DIFF
--- a/windows/src/wmi.cc
+++ b/windows/src/wmi.cc
@@ -31,7 +31,7 @@ namespace leatherman { namespace windows {
     wmi::wmi()
     {
         LOG_DEBUG("initializing WMI");
-        auto hres = CoInitializeEx(0, COINIT_MULTITHREADED);
+        auto hres = CoInitializeEx(0, COINIT_APARTMENTTHREADED);
         if (FAILED(hres)) {
             if (hres == RPC_E_CHANGED_MODE) {
                 LOG_DEBUG("using prior COM concurrency model");


### PR DESCRIPTION
The wmi utility was moved to Leatherman after Facter 3.0 was released,
so some merges from stable to master require merges across-project to
Leatherman. Merge the FACT-1082 fix for COM initialization.