### PR TITLE
(maint) Moved relative_file_list() and associated structs back to pegasus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ compile_commands.json
 /release*/
 /.idea/
 /build/
+/linux-build/

--- a/file_util/inc/leatherman/file_util/file.hpp
+++ b/file_util/inc/leatherman/file_util/file.hpp
@@ -68,18 +68,6 @@ namespace leatherman { namespace file_util {
      */
     std::string shell_quote(std::string path);
 
-    struct file_copy {
-        boost::filesystem::path source;
-        std::string relativeName;
-    };
-
-    using file_list = std::vector<file_copy>;
-
-    /**
-     * @return Returns a set of files suitable for copying
-     */
-    file_list relative_file_list(boost::filesystem::path path);
-
     /**
      * @return Returns the home path for the current platform.
      */

--- a/file_util/src/file.cc
+++ b/file_util/src/file.cc
@@ -96,28 +96,6 @@ namespace boost_file = boost::filesystem;
         return ss.str();
     }
 
-    file_list relative_file_list(boost_file::path path) {
-        file_list list;
-        std::string common_prefix { path.string() };
-        std::string prefix_filename { path.filename().string() };
-
-        list.emplace_back(file_copy { path, path.filename().string() });
-
-        if (prefix_filename == ".") {
-            // when we're scanning '.' remove all the prefix
-            prefix_filename = "";
-        }
-
-        boost_file::recursive_directory_iterator walker { path };
-        for (; walker != boost_file::recursive_directory_iterator(); walker++) {
-            std::string target_path { walker->path().string() };
-            assert((std::string { target_path, 0, common_prefix.size() } == common_prefix));
-            target_path.replace(0, common_prefix.size(), prefix_filename);
-            list.emplace_back(file_copy { walker->path(), target_path });
-        }
-        return list;
-    }
-
     std::string get_home_path() {
         #ifdef _WIN32
             auto home_var = "USERPROFILE";


### PR DESCRIPTION
The verdict was reached that this method is only useful in Pegasus, so there is no reason to make it generally available.