### PR TITLE
(maint) Remove unused libraries in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
       - libboost-log1.55-dev
       - libboost-locale1.55-dev
       - libboost-chrono1.55-dev
-      - libblkid1
 
 before_install:
   # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.


### PR DESCRIPTION
libblkid is not used by Leatherman, so remove it from the TravisCI
config.