### PR TITLE
(maint) Extend logging tests

### DIFF
--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -15,6 +15,7 @@
 #include <boost/log/sinks/basic_sink_backend.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/algorithm/string.hpp>
 
 #pragma GCC diagnostic pop
 
@@ -156,6 +157,7 @@ namespace leatherman { namespace logging {
     {
         string value;
         if (in >> value) {
+            boost::algorithm::to_lower(value);
             if (value == "none") {
                 level = log_level::none;
                 return in;
@@ -185,7 +187,7 @@ namespace leatherman { namespace logging {
                 return in;
             }
         }
-        throw runtime_error("invalid log level: expected none, trace, debug, info, warn, error, or fatal.");
+        throw runtime_error((boost::format("invalid log level '%1%': expected none, trace, debug, info, warn, error, or fatal.") % level).str());
     }
 
     ostream& operator<<(ostream& strm, log_level level)

--- a/logging/tests/logging_sink.cc
+++ b/logging/tests/logging_sink.cc
@@ -13,8 +13,14 @@ struct custom_log_appender :
 {
     void consume(boost::log::record_view const& rec, string_type const& message)
     {
+        auto lvl = boost::log::extract<log_level>("Severity", rec);
         stringstream s;
         s << boost::log::extract<log_level>("Severity", rec);
+
+        log_level read_lvl;
+        s >> read_lvl;
+        REQUIRE(read_lvl == lvl);
+
         _level = s.str();
         _message = message;
     }
@@ -30,6 +36,7 @@ struct logging_test_context
     logging_test_context(log_level lvl = log_level::trace)
     {
         set_level(lvl);
+        REQUIRE(get_level() == lvl);
         clear_error_logged_flag();
 
         colorize(_color, lvl);
@@ -45,6 +52,7 @@ struct logging_test_context
     ~logging_test_context()
     {
         set_level(log_level::none);
+        REQUIRE(get_level() == log_level::none);
         on_message(nullptr);
         clear_error_logged_flag();
 


### PR DESCRIPTION
Extends testing to cover `operator>>` and `get_level`, completing line
coverage of the logging module.