### PR TITLE
(maint) Move CURL_STATIC to Leatherman

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
 
 build_script:
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON .
   - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
   - ps: mingw32-make
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,7 @@
 include(leatherman)
 defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
 defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
+defoption(CURL_STATIC "Use curl's static libraries" OFF)
 
 # Map our boost option to the for-realsies one
 set(Boost_USE_STATIC_LIBS ${BOOST_STATIC})

--- a/curl/CMakeLists.txt
+++ b/curl/CMakeLists.txt
@@ -1,9 +1,18 @@
 find_package(CURL REQUIRED)
 
+if (CURL_STATIC)
+    add_definitions(-DCURL_STATICLIB)
+    if (WIN32)
+        # Linking statically on Windows requires some extra libraries.
+        set(CURL_DEPS wldap32.lib ws2_32.lib)
+    endif()
+endif()
+
 add_leatherman_includes("${CURL_INCLUDE_DIRS}")
 
 leatherman_dependency(logging)
 leatherman_dependency(util)
+add_leatherman_deps(${CURL_LIBRARIES} ${CURL_DEPS})
 
 if (BUILDING_LEATHERMAN)
     leatherman_logging_namespace("leatherman.curl")
@@ -12,5 +21,3 @@ endif()
 
 add_leatherman_library(src/client.cc src/request.cc src/response.cc)
 add_leatherman_headers(inc/leatherman)
-
-target_link_libraries(leatherman_curl "${CURL_LIBRARIES}")


### PR DESCRIPTION
Without this change, no option is provided within Leatherman to link
against a static build of libcurl. On Windows, setting CURL_STATICLIB is
required to build against a static build of libcurl to resolve symbols.

Move the CURL_STATIC option and basic configuration from Facter to
Leatherman.