### PR TITLE
(maint) Ignore coveralls failures

### DIFF
--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -42,7 +42,8 @@ function travis_make()
         fi
 
         if [ $1 == "debug" ]; then
-            coveralls --gcov gcov-4.8 --gcov-options '\-lp' -r .. >/dev/null
+            # Ignore coveralls results, keep service success uncoupled
+            coveralls --gcov gcov-4.8 --gcov-options '\-lp' -r .. >/dev/null || true
         fi
     fi
 }


### PR DESCRIPTION
Don't fail Travis if uploading to coveralls fails. This is a judgement
call, but coveralls is not essential and may be ignored if the service
is unavailable. If a service goes down, we'd rather it didn't affect the
results of other services.