### PR TITLE
(maint) Add missing <functional> include to strings.hpp

### DIFF
--- a/util/inc/leatherman/util/strings.hpp
+++ b/util/inc/leatherman/util/strings.hpp
@@ -6,6 +6,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/compare.hpp>
+#include <functional>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This is apparently pulled in automatically from other headers on some
compiler versions, but not on my GCC 5.2.0