### PR TITLE
(FACT-1123) Add LoadError to ruby API bindings

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -393,6 +393,10 @@ namespace leatherman {  namespace ruby {
          * See MRI documentation.
          */
         VALUE* const rb_eRuntimeError;
+        /**
+         * See MRI documentation.
+         */
+        VALUE* const rb_eLoadError;
 
         /**
          * Gets the load path being used by Ruby.

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -95,6 +95,7 @@ namespace leatherman { namespace ruby {
         LOAD_SYMBOL(rb_eTypeError),
         LOAD_SYMBOL(rb_eStandardError),
         LOAD_SYMBOL(rb_eRuntimeError),
+        LOAD_SYMBOL(rb_eLoadError),
         LOAD_OPTIONAL_SYMBOL(ruby_setup),
         LOAD_SYMBOL(ruby_init),
         LOAD_SYMBOL(ruby_options),


### PR DESCRIPTION
The fact-1123 implementation uses a LoadError to signal when
initialization of libfacter has failed. This ports the necessary
changes from facter.