### PR TITLE
(maint) Set Content-Length header based on size of the body

### DIFF
--- a/curl/src/request.cc
+++ b/curl/src/request.cc
@@ -82,6 +82,7 @@ namespace leatherman { namespace curl {
     {
         _body = move(body);
         add_header("Content-Type", move(content_type));
+        add_header("Content-Length", to_string(_body.size()));
     }
 
     string const& request::body() const

--- a/curl/tests/request_test.cc
+++ b/curl/tests/request_test.cc
@@ -75,6 +75,15 @@ namespace leatherman { namespace curl {
             REQUIRE(body == "Hello, I am a request body!");
         }
 
+        SECTION("Content-Length should be set based on size of the body") {
+          string msg = "This is the request body";
+          test_request.body(msg, "test");
+          auto content_length = test_request.header("Content-Length");
+
+          REQUIRE(content_length);
+          REQUIRE(*content_length == to_string(msg.size()));
+        }
+
         SECTION("Overall request timeout should be configurable and retrievable") {
             test_request.timeout(100);
             REQUIRE(test_request.timeout() == 100);


### PR DESCRIPTION
When providing a body to a POST request, setting the Content-Length
header to the size of the body is required in order for the server to
properly read the body. Currently that's a manual process that always
needs to be done, in the same way, by the user of the curl client for
every request. Since the behavior is always the same and it's always
necessary, the body setter now computes and adds the header
automatically. This can still be overridden by the consumer by setting
the header before adding the body, if they don't want it set (though
it's hard to imagine a reason for that).