### PR TITLE
(maint) Add rt dependency for Boost.Thread

### DIFF
--- a/logging/CMakeLists.txt
+++ b/logging/CMakeLists.txt
@@ -7,6 +7,10 @@ add_leatherman_includes("${Boost_INCLUDE_DIRS}")
 leatherman_dependency(nowide)
 leatherman_dependency(locale)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "SunOS")
+    add_leatherman_deps(rt)
+endif()
+
 if (BUILDING_LEATHERMAN)
     leatherman_logging_namespace("leatherman.logging")
     leatherman_logging_line_numbers()


### PR DESCRIPTION
On some Linux and Solaris versions, rt must be explicitly linked as a
dependency for libboost_thread. Add it to dependencies in Logging, the
only library that uses Boost.Thread.