### PR TITLE
(LTH-40) Remove build requirement on Ruby

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
 
 build_script:
   - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON -DRUBY_LIBRARY="C:\Ruby21-x64\lib" .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON .
   - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
   - ps: mingw32-make
 

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(Ruby 1.9 REQUIRED)
-
 leatherman_dependency(dynamic_library)
 leatherman_dependency(util)
 leatherman_dependency(execution)


### PR DESCRIPTION
Ruby isn't required to build Leatherman.Ruby, so remove the dependency on it.
Instead let the unit tests fail if Ruby's not present.