### PR TITLE
(LTH-41) Add function to specify curl protocols

### DIFF
--- a/curl/inc/leatherman/curl/client.hpp
+++ b/curl/inc/leatherman/curl/client.hpp
@@ -201,7 +201,7 @@ namespace leatherman { namespace curl {
         std::string _ca_cert;
         std::string _client_cert;
         std::string _client_key;
-        long _client_protocols;
+        long _client_protocols = CURLPROTO_ALL;
 
         response perform(http_method method, request const& req);
         void set_method(context& ctx, http_method method);

--- a/curl/inc/leatherman/curl/client.hpp
+++ b/curl/inc/leatherman/curl/client.hpp
@@ -164,6 +164,13 @@ namespace leatherman { namespace curl {
          */
         void set_client_cert(std::string const& client_cert, std::string const& client_key);
 
+        /**
+         * Set and limit what protocols curl will support
+         * @param client_protocols bitmask of CURLPROTO_*
+         *        (see more: http://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html)
+         */
+        void set_supported_protocols(long client_protocols);
+
      private:
         client(client const&) = delete;
         client& operator=(client const&) = delete;
@@ -194,6 +201,7 @@ namespace leatherman { namespace curl {
         std::string _ca_cert;
         std::string _client_cert;
         std::string _client_key;
+        long _client_protocols;
 
         response perform(http_method method, request const& req);
         void set_method(context& ctx, http_method method);
@@ -205,6 +213,7 @@ namespace leatherman { namespace curl {
         void set_write_callbacks(context& ctx);
         void set_client_info(context &ctx);
         void set_ca_info(context& ctx);
+        void set_client_protocols(context& ctx);
 
         static size_t read_body(char* buffer, size_t size, size_t count, void* ptr);
         static size_t write_header(char* buffer, size_t size, size_t count, void* ptr);

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -154,6 +154,7 @@ namespace leatherman { namespace curl {
         set_write_callbacks(ctx);
         set_ca_info(ctx);
         set_client_info(ctx);
+        set_client_protocols(ctx);
 
         // Perform the request
         result = curl_easy_perform(_handle);
@@ -177,6 +178,10 @@ namespace leatherman { namespace curl {
     {
         _client_cert = client_cert;
         _client_key = client_key;
+    }
+
+    void client::set_supported_protocols(long client_protocols) {
+        _client_protocols = client_protocols;
     }
 
     void client::set_method(context& ctx, http_method method)
@@ -309,6 +314,19 @@ namespace leatherman { namespace curl {
             if (result != CURLE_OK) {
                 throw http_request_exception(ctx.req, curl_easy_strerror(result));
             }
+        }
+    }
+
+    void client::set_client_protocols(context& ctx) {
+        if (!_client_protocols) {
+            // If not set, allow all protocols
+            _client_protocols = CURLPROTO_ALL;
+            LOG_WARNING("No client protocol was set. Allowing all protocols.", _client_protocols);
+        }
+
+        auto result = curl_easy_setopt(_handle, CURLOPT_PROTOCOLS, _client_protocols);
+        if (result != CURLE_OK) {
+            throw http_request_exception(ctx.req, curl_easy_strerror(result));
         }
     }
 

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -321,7 +321,7 @@ namespace leatherman { namespace curl {
         if (!_client_protocols) {
             // If not set, allow all protocols
             _client_protocols = CURLPROTO_ALL;
-            LOG_WARNING("No client protocol was set. Allowing all protocols.", _client_protocols);
+            LOG_WARNING("No client protocol was set. Allowing all protocols.");
         }
 
         auto result = curl_easy_setopt(_handle, CURLOPT_PROTOCOLS, _client_protocols);

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -318,12 +318,6 @@ namespace leatherman { namespace curl {
     }
 
     void client::set_client_protocols(context& ctx) {
-        if (!_client_protocols) {
-            // If not set, allow all protocols
-            _client_protocols = CURLPROTO_ALL;
-            LOG_WARNING("No client protocol was set. Allowing all protocols.");
-        }
-
         auto result = curl_easy_setopt(_handle, CURLOPT_PROTOCOLS, _client_protocols);
         if (result != CURLE_OK) {
             throw http_request_exception(ctx.req, curl_easy_strerror(result));

--- a/curl/tests/client_test.cc
+++ b/curl/tests/client_test.cc
@@ -231,6 +231,14 @@ namespace leatherman { namespace curl {
             auto test_impl = static_cast<curl_impl* const>(handle);
             REQUIRE(test_impl->client_key == "key");
         }
+
+        SECTION("cURL should make an HTTP request with the specified HTTP protocol") {
+            test_client.set_supported_protocols(CURLPROTO_HTTP);
+            auto resp = test_client.get(test_request);
+            CURL* const& handle = test_client.get_handle();
+            auto test_impl = static_cast<curl_impl* const>(handle);
+            REQUIRE(test_impl->protocols == CURLPROTO_HTTP);
+        }
     }
 
     TEST_CASE("curl::client errors") {
@@ -335,6 +343,12 @@ namespace leatherman { namespace curl {
         SECTION("client fails to set SSL key info") {
             test_client.set_client_cert("cert", "key");
             test_impl->test_failure_mode = curl_impl::error_mode::ssl_key_error;
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+        }
+
+        SECTION("client fails to make http call with https protocol only enabled") {
+            test_client.set_supported_protocols(CURLPROTO_HTTPS);
+            test_impl->test_failure_mode = curl_impl::error_mode::protocol_error;
             REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
         }
     }

--- a/curl/tests/client_test.cc
+++ b/curl/tests/client_test.cc
@@ -239,6 +239,13 @@ namespace leatherman { namespace curl {
             auto test_impl = static_cast<curl_impl* const>(handle);
             REQUIRE(test_impl->protocols == CURLPROTO_HTTP);
         }
+
+        SECTION("cURL defaults to all protocols if no protocols are specified") {
+            auto resp = test_client.get(test_request);
+            CURL* const& handle = test_client.get_handle();
+            auto test_impl = static_cast<curl_impl* const>(handle);
+            REQUIRE(test_impl->protocols == CURLPROTO_ALL);
+        }
     }
 
     TEST_CASE("curl::client errors") {

--- a/curl/tests/mock_curl.cc
+++ b/curl/tests/mock_curl.cc
@@ -226,6 +226,13 @@ CURLcode curl_easy_setopt(CURL *handle, CURLoption option, ...)
                 return CURLE_COULDNT_CONNECT;
             }
             break;
+        case CURLOPT_PROTOCOLS:
+            if (h->test_failure_mode == curl_impl::error_mode::protocol_error) {
+                va_end(vl);
+                return CURLE_COULDNT_CONNECT;
+            }
+            h->protocols = va_arg(vl, long);
+            break;
         default:
             break;
     }

--- a/curl/tests/mock_curl.hpp
+++ b/curl/tests/mock_curl.hpp
@@ -33,6 +33,7 @@ struct curl_impl
         ca_bundle_error,
         ssl_cert_error,
         ssl_key_error,
+        protocol_error,
     };
 
     error_mode test_failure_mode = error_mode::success;
@@ -50,6 +51,7 @@ struct curl_impl
     void* read_data; // Where to read the request body from
 
     std::string request_url, cookie, cacert, client_cert, client_key;
+    long protocols;
     http_method method = http_method::get;
 
     curl_slist* header; // List of custom request headers to be passed to the server


### PR DESCRIPTION
This commit adds a wrapper to specify CURLOPT_PROTOCOLS per a curl
request. If no protocol is defined, it will default to all protocols. If
a protocol is defined but one is used that wasn't specified (like using
http when https was the only protocol enabled), it will fail with an
http exception saying that an unsupported protocol was used.