### PR TITLE
(FACT-891) Always assume dynamic_library::load is first load

### DIFF
--- a/dynamic_library/inc/leatherman/dynamic_library/dynamic_library.hpp
+++ b/dynamic_library/inc/leatherman/dynamic_library/dynamic_library.hpp
@@ -74,6 +74,8 @@ namespace leatherman { namespace dynamic_library {
         /**
          * Loads the given dynamic library.
          * The current library will be closed before the given library is loaded.
+         * If you rely on the value of first_load(), you should try to call find_by_symbol
+         * before calling this function.
          * @param name The name of the library to load.
          * @return Returns true if the library loaded or false if it did not.
          */

--- a/dynamic_library/src/posix/dynamic_library.cc
+++ b/dynamic_library/src/posix/dynamic_library.cc
@@ -41,26 +41,12 @@ namespace leatherman { namespace dynamic_library {
 
         auto load_mode = (global ? RTLD_GLOBAL : RTLD_LOCAL) | RTLD_LAZY;
 
-        // Don't actually perform a load to determine if it is already loaded
-#if !defined(RTLD_NOLOAD)
-        // HACK HACK HACK HACK HACK
-
-        // On AIX, RTLD_NOLOAD doesn't exist. This gets things to compile
-        // there, but is WRONG and will most likely BREAK at runtime.
-        // FACT-891 needs to be resolved.
         _handle = dlopen(name.c_str(), load_mode);
-#else
-        _handle = dlopen(name.c_str(), RTLD_NOLOAD | load_mode);
-#endif
         if (!_handle) {
-            // Load now
-            _handle = dlopen(name.c_str(), load_mode);
-            if (!_handle) {
-                LOG_DEBUG("library %1% not found %2% (%3%).", name.c_str(), strerror(errno), errno);
-                return false;
-            }
-            _first_load = true;
+            LOG_DEBUG("library %1% not found %2% (%3%).", name.c_str(), strerror(errno), errno);
+            return false;
         }
+        _first_load = true;
         _name = name;
         return true;
     }


### PR DESCRIPTION
It's not possible on all platforms to check if a library has been loaded. Instead, the right thing to do is use dynamic_library::find_by_sybmol and only call load if that failed. Since that's the new recommended API usage, and since Facter already does the right thing, load can now unconditionally flag the library as first_load.