### PR TITLE
(LTH-43) Add getWithDefault to JsonContainer.

### DIFF
--- a/json_container/inc/leatherman/json_container/json_container.hpp
+++ b/json_container/inc/leatherman/json_container/json_container.hpp
@@ -246,6 +246,26 @@ namespace leatherman { namespace json_container {
             return getValue<T>(*getValueInJson(keys, true, idx));
         }
 
+        /// Return the value of the specified entry of the root object,
+        /// or default_value if the entry doesn't exist.
+        /// Throw a data_type_error in case the type T doesn't match
+        /// the specified one.
+        template <typename T>
+        T getWithDefault(const JsonContainerKey& key, const T default_value) {
+            auto jval = getValueInJson();
+            auto key_data = key.data();
+
+            if (!isObject(*jval)) {
+                throw data_type_error { "not an object" };
+            }
+
+            if (!hasKey(*jval, key_data)) {
+                return default_value;
+            }
+
+            return getValue<T>(*getValueInJson(*jval, key_data));
+        }
+
         /// Throw a data_key_error in case the root is not a valid JSON
         /// object, so that is not possible to set the entry.
         template <typename T>

--- a/json_container/tests/json_container_test.cc
+++ b/json_container/tests/json_container_test.cc
@@ -157,6 +157,21 @@ TEST_CASE("JsonContainer::get for object entries", "[data]") {
         }
     }
 
+    SECTION("it can provide a default value if the key is not found") {
+      REQUIRE(msg.getWithDefault<int>("dne", 42) == 42);
+      REQUIRE(msg.getWithDefault<double>("dne", 42.0) == 42.0);
+      REQUIRE(msg.getWithDefault<bool>("dne", true) == true);
+      REQUIRE(msg.getWithDefault<std::string>("dne", "foo") == "foo");
+      std::vector<int> ints{1, 2, 3};
+      std::vector<double> doubles{1.0, 2.0, 3.0};
+      std::vector<bool> bools{false, true, false};
+      std::vector<std::string> strings{"foo", "bar", "baz"};
+      REQUIRE(msg.getWithDefault<std::vector<int>>("dne", ints) == ints);
+      REQUIRE(msg.getWithDefault<std::vector<double>>("dne", doubles) == doubles);
+      REQUIRE(msg.getWithDefault<std::vector<bool>>("dne", bools) == bools);
+      REQUIRE(msg.getWithDefault<std::vector<std::string>>("dne", strings) == strings);
+    }
+
     JsonContainer data { JSON };
 
     SECTION("it throws a data_key_error in case of unknown object entry") {


### PR DESCRIPTION
Before this patch, if users of JsonContainer wanted to try to find
an entry in a JSON object and use a default value if the entry was not
found, they would have to perform a two-step process of checking for the
key and then either getting the key or using the default value. This is
more work than is strictly necessary and leads to superfluous repetition
of this logic. With this patch applied, that logic is centralized in the
`getWithDefault` method, and users can call that function with their
default value instead of implementing the logic themselves.