### PR TITLE
(maint) Port fix in facter#stable to Leatherman execution library.

### DIFF
--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -53,6 +53,10 @@ namespace leatherman { namespace execution {
          */
         redirect_stderr_to_null = (1 << 6),
         /**
+         * Preserve (do not quote) arguments.
+         */
+        preserve_arguments = (1 << 7),
+        /**
          * A combination of all throw options.
          */
         throw_on_failure = throw_on_nonzero_exit | throw_on_signal,

--- a/execution/src/execution.cc
+++ b/execution/src/execution.cc
@@ -96,10 +96,11 @@ namespace leatherman { namespace execution {
             return {};
         }
 
-        string quote = result[0] == '"' || result[0] == '\'' ? string(1, result[0]) : "";
+        bool quoted = result[0] == '"' || result[0] == '\'';
+
         string file;
         string remainder;
-        if (!quote.empty()) {
+        if (quoted) {
             // Look for the ending quote for the command
             auto pos = result.find(result[0], 1);
             if (pos == string::npos) {
@@ -107,7 +108,7 @@ namespace leatherman { namespace execution {
                 file = result.substr(1);
             } else {
                 file = result.substr(1, pos - 1);
-                remainder = result.substr(pos);
+                remainder = result.substr(pos + 1);
             }
         } else {
             auto pos = command.find(' ');
@@ -123,7 +124,16 @@ namespace leatherman { namespace execution {
         if (file.empty()) {
             return {};
         }
-        return quote + file + remainder;
+
+        // If originally unquoted and the expanded file has a space, quote it
+        if (!quoted && file.find(' ') != string::npos) {
+            return "\"" + file + "\"" + remainder;
+        } else if (quoted) {
+            // Originally quoted, use the same quote characters
+            return result[0] + file + result[0] + remainder;
+        }
+        // Not quoted
+        return file + remainder;
     }
 
     tuple<bool, string, string> execute(

--- a/execution/src/windows/execution.cc
+++ b/execution/src/windows/execution.cc
@@ -154,7 +154,7 @@ namespace leatherman { namespace execution {
     }
 
     // Source: http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
-    static string ArgvToCommandLine(vector<string> const& arguments)
+    static string ArgvToCommandLine(vector<string> const& arguments, bool preserve = false)
     {
         // Unless we're told otherwise, don't quote unless we actually need to do so - hopefully avoid problems if
         // programs won't parse quotes properly.
@@ -162,7 +162,7 @@ namespace leatherman { namespace execution {
         for (auto const& arg : arguments) {
             if (arg.empty()) {
                 continue;
-            } else if (arg.find_first_of(" \t\n\v\"") == arg.npos) {
+            } else if (preserve || arg.find_first_of(" \t\n\v\"") == arg.npos) {
                 commandline += arg;
             } else {
                 commandline += '"';
@@ -468,7 +468,7 @@ namespace leatherman { namespace execution {
 
         // Execute the command with arguments. Prefix arguments with the executable, or quoted arguments won't work.
         auto commandLine = arguments ?
-            boost::nowide::widen(ArgvToCommandLine({ executable }) + " " + ArgvToCommandLine(*arguments)) : L"";
+            boost::nowide::widen(ArgvToCommandLine({ executable }) + " " + ArgvToCommandLine(*arguments, options[execution_options::preserve_arguments])) : L"";
 
         STARTUPINFO startupInfo = {};
         startupInfo.cb = sizeof(startupInfo);


### PR DESCRIPTION
This ports the fix for FACT-1158 (failure to properly expand commands for Ruby
command execution) that is currently in facter's stable branch to Leatherman.

The fix is to properly quote expanded commands that contain spaces.
Additionally, a new option is added to preserve the arguments so that they
aren't automatically quoted on Windows.