### PR TITLE
(maint) Merge facter#stable Ruby API changes

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -115,6 +115,13 @@ namespace leatherman {  namespace ruby {
          */
         bool initialized() const;
 
+         /**
+         * Called to uninitialize the API.
+         * Called during destruction, but can also be called earlier to cleanup Ruby, avoiding potential
+         * ordering conflicts between unloading the libfacter DLL and libruby DLL.
+         */
+        void uninitialize();
+
         /**
          * Gets whether or not exception stack traces are included when formatting exception messages.
          * @return Returns true if stack traces will be included in exception messages or false if they will not be.

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -106,19 +106,7 @@ namespace leatherman { namespace ruby {
 
     api::~api()
     {
-        // API is shutting down; free all remaining data objects
-        // Destructors may unregister the data object, so increment the iterator before freeing
-        for (auto it = _data_objects.begin(); it != _data_objects.end();) {
-            auto data = reinterpret_cast<RData*>(*it);
-            ++it;
-            if (data->dfree) {
-                data->dfree(data->data);
-                data->dfree = nullptr;
-            }
-        }
-        if (_initialized && _library.first_load()) {
-            ruby_cleanup(0);
-        }
+        uninitialize();
     }
 
     api& api::instance()
@@ -193,6 +181,26 @@ namespace leatherman { namespace ruby {
     bool api::initialized() const
     {
         return _initialized;
+    }
+
+    void api::uninitialize()
+    {
+        // API is shutting down; free all remaining data objects
+        // Destructors may unregister the data object, so increment the iterator before freeing
+        for (auto it = _data_objects.begin(); it != _data_objects.end();) {
+            auto data = reinterpret_cast<RData*>(*it);
+            ++it;
+            if (data->dfree) {
+                data->dfree(data->data);
+                data->dfree = nullptr;
+            }
+        }
+        _data_objects.clear();
+
+        if (_initialized && _library.first_load()) {
+            ruby_cleanup(0);
+            _initialized = false;
+        }
     }
 
     bool api::include_stack_trace() const


### PR DESCRIPTION
In Facter#stable, the Ruby API was updated to include an uninitialize
method for cleaning up Ruby before DLL unload. Move it to Leatherman.