### PR TITLE
(LTH-29) Add an option to override logging namespace at runtime

### DIFF
--- a/logging/inc/leatherman/logging/logging.hpp
+++ b/logging/inc/leatherman/logging/logging.hpp
@@ -20,10 +20,10 @@
 /**
  * Defines the logging namespace.
  */
-#ifndef LEATHERMAN_LOGGING_NAMESPACE
-#error "LEATHERMAN_LOGGING_NAMESPACE must be set. This is typically done via CMake."
-#else
+#ifdef LEATHERMAN_LOGGING_NAMESPACE
 #define LOG_NAMESPACE LEATHERMAN_LOGGING_NAMESPACE
+#else
+#define LOG_NAMESPACE ""
 #endif
 
 
@@ -37,12 +37,20 @@
 #ifdef LEATHERMAN_LOGGING_LINE_NUMBERS
 #define LOG_MESSAGE(level, line_num, format, ...) \
     if (leatherman::logging::is_enabled(level)) { \
-        leatherman::logging::log(LOG_NAMESPACE, level, line_num, format, ##__VA_ARGS__); \
+        if (leatherman::logging::override_namespace.empty()) { \
+            leatherman::logging::log(LOG_NAMESPACE, level, line_num, format, ##__VA_ARGS__); \
+        } else { \
+            leatherman::logging::log(leatherman::logging::override_namespace, level, 0, format, ##__VA_ARGS__); \
+        } \
     }
 #else
 #define LOG_MESSAGE(level, line_num, format, ...) \
     if (leatherman::logging::is_enabled(level)) { \
-        leatherman::logging::log(LOG_NAMESPACE, level, 0, format, ##__VA_ARGS__); \
+        if (leatherman::logging::override_namespace.empty()) { \
+            leatherman::logging::log(LOG_NAMESPACE, level, 0, format, ##__VA_ARGS__); \
+        } else { \
+            leatherman::logging::log(leatherman::logging::override_namespace, level, 0, format, ##__VA_ARGS__); \
+        } \
     }
 #endif
 /**
@@ -127,6 +135,13 @@ namespace leatherman { namespace logging {
         error,
         fatal
     };
+
+    /**
+     * The override namespace. If not empty, the LOG_* macros will use the override namespace rather
+     * than the LEATHERMAN_LOGGING_NAMESPACE for log messages. Setting this will also cause line numbers
+     * to be ignored.
+     */
+    extern std::string override_namespace;
 
     /**
      * Reads a log level from an input stream.

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -32,6 +32,7 @@ namespace leatherman { namespace logging {
     static log_level g_level = log_level::none;
     static bool g_colorize = false;
     static bool g_error_logged = false;
+    string override_namespace;
 
     class color_writer : public sinks::basic_sink_backend<sinks::synchronized_feeding>
     {

--- a/logging/tests/logging_sink.cc
+++ b/logging/tests/logging_sink.cc
@@ -23,21 +23,26 @@ struct custom_log_appender :
 
         _level = s.str();
         _message = message;
+        _namespace = boost::log::extract<string>("Namespace", rec).get();
     }
 
     string _level;
     string _message;
+    string _namespace;
 };
 
 struct logging_test_context
 {
     using sink_t = sinks::synchronous_sink<custom_log_appender>;
 
-    logging_test_context(log_level lvl = log_level::trace)
+    logging_test_context(log_level lvl = log_level::trace, string ns = "")
     {
         set_level(lvl);
         REQUIRE(get_level() == lvl);
         clear_error_logged_flag();
+        if (!ns.empty()) {
+            override_namespace = ns;
+        }
 
         colorize(_color, lvl);
         colorize(_none);
@@ -55,6 +60,7 @@ struct logging_test_context
         REQUIRE(get_level() == log_level::none);
         on_message(nullptr);
         clear_error_logged_flag();
+        override_namespace = "";
 
         auto core = boost::log::core::get();
         core->reset_filter();
@@ -72,6 +78,11 @@ struct logging_test_context
     string const& message() const
     {
         return _appender->_message;
+    }
+
+    string const& ns() const
+    {
+        return _appender->_namespace;
     }
 
     string color() const
@@ -96,9 +107,11 @@ SCENARIO("logging with a TRACE level") {
     LOG_TRACE("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "TRACE");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == LEATHERMAN_LOGGING_NAMESPACE);
     log("test", log_level::trace, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "TRACE");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == "test");
     REQUIRE_FALSE(error_has_been_logged());
 }
 
@@ -108,9 +121,11 @@ SCENARIO("logging with a DEBUG level") {
     LOG_DEBUG("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "DEBUG");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == LEATHERMAN_LOGGING_NAMESPACE);
     log("test", log_level::debug, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "DEBUG");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == "test");
     REQUIRE_FALSE(error_has_been_logged());
 }
 
@@ -120,9 +135,11 @@ SCENARIO("logging with an INFO level") {
     LOG_INFO("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "INFO");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == LEATHERMAN_LOGGING_NAMESPACE);
     log("test", log_level::info, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "INFO");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == "test");
     REQUIRE_FALSE(error_has_been_logged());
 }
 
@@ -132,9 +149,11 @@ SCENARIO("logging with a WARNING level") {
     LOG_WARNING("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "WARN");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == LEATHERMAN_LOGGING_NAMESPACE);
     log("test", log_level::warning, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "WARN");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == "test");
     REQUIRE_FALSE(error_has_been_logged());
 }
 
@@ -144,9 +163,11 @@ SCENARIO("logging with an ERROR level") {
     LOG_ERROR("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "ERROR");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == LEATHERMAN_LOGGING_NAMESPACE);
     log("test", log_level::error, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "ERROR");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == "test");
     REQUIRE(error_has_been_logged());
 }
 
@@ -156,10 +177,21 @@ SCENARIO("logging with a FATAL level") {
     LOG_FATAL("testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "FATAL");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == LEATHERMAN_LOGGING_NAMESPACE);
     log("test", log_level::fatal, 0, "testing %1% %2% %3%", 1, "2", 3.0);
     REQUIRE(context.level() == "FATAL");
     REQUIRE(context.message() == context.color() + "testing 1 2 3" + context.none());
+    REQUIRE(context.ns() == "test");
     REQUIRE(error_has_been_logged());
+}
+
+SCENARIO("logging with an override namespace") {
+    logging_test_context context(log_level::warning, "custom");
+    LOG_WARNING("testing");
+    REQUIRE(context.ns() == "custom");
+    log("test", log_level::warning, 0, "testing");
+    REQUIRE(context.ns() == "test");
+    REQUIRE_FALSE(error_has_been_logged());
 }
 
 SCENARIO("logging with on_message") {


### PR DESCRIPTION
When building Leatherman, it specifies a logging namespace for each
Leatherman library. When Leatherman is distributed as a compiled
package, those namespaces can't be overridden, resulting in log messages
that the consuming project can't control.

Introduce a method to override logging namespaces at runtime, so
projects can set their own namespace to override Leatherman.