### PR TITLE
(FACT-1230) Don't try to use locale on AIX

### DIFF
--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -75,7 +75,7 @@ namespace leatherman { namespace logging {
         boost::shared_ptr<sink_t> sink(new sink_t(&dst));
         core->add_sink(sink);
 
-#if !defined(__sun) || !defined(__GNUC__)
+#if (!defined(__sun) && !defined(_AIX)) || !defined(__GNUC__)
         // Imbue the logging sink with the requested locale.
         // Locale in GCC is busted on Solaris, so skip it.
         dst.imbue(leatherman::locale::get_locale(locale));


### PR DESCRIPTION
Just like on Solaris, libstdc++'s locale support is kind of borked on AIX. We shouldn't even bother.