### PR TITLE
(LTH-48) Return exit_code from execute command

### DIFF
--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -207,9 +207,9 @@ namespace leatherman { namespace execution {
      * @param file The name or path of the program to execute.
      * @param timeout The timeout, in seconds.  Defaults to no timeout.
      * @param options The execution options.  Defaults to trimming output, merging the environment, and redirecting stderr to null.
-     * @return Returns a tuple of whether or not the command succeeded, output from stdout, and output from stderr (if not redirected).
+     * @return Returns a tuple of whether or not the command succeeded, output from stdout, output from stderr (if not redirected), and the exit code.
      */
-    std::tuple<bool, std::string, std::string> execute(
+    std::tuple<bool, std::string, std::string, int> execute(
         std::string const& file,
         uint32_t timeout = 0,
         lth_util::option_set<execution_options> const& options = { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null });
@@ -220,9 +220,9 @@ namespace leatherman { namespace execution {
      * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @param options The execution options.  Defaults to trimming output, merging the environment, and redirecting stderr to null.
-     * @return Returns a tuple of whether or not the command succeeded, output from stdout, and output from stderr (if not redirected).
+     * @return Returns a tuple of whether or not the command succeeded, output from stdout, output from stderr (if not redirected), and the exit code.
      */
-    std::tuple<bool, std::string, std::string> execute(
+    std::tuple<bool, std::string, std::string, int> execute(
         std::string const& file,
         std::vector<std::string> const& arguments,
         uint32_t timeout = 0,
@@ -235,9 +235,9 @@ namespace leatherman { namespace execution {
      * @param environment The environment variables to pass to the child process.
      * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @param options The execution options.  Defaults to trimming output, merging the environment, and redirecting stderr to null.
-     * @return Returns a tuple of whether or not the command succeeded, output from stdout, and output from stderr (if not redirected).
+     * @return Returns a tuple of whether or not the command succeeded, output from stdout, output from stderr (if not redirected), and the exit code.
      */
-    std::tuple<bool, std::string, std::string> execute(
+    std::tuple<bool, std::string, std::string, int> execute(
         std::string const& file,
         std::vector<std::string> const& arguments,
         std::map<std::string, std::string> const& environment,

--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -192,9 +192,14 @@ namespace leatherman { namespace execution {
     struct result
     {
         /**
-         * Whether or not the command succeeded.
+         * Constructor.
          */
-        bool success;
+        result(bool s, std::string o, std::string e, int ec)
+            : success(s), output(move(o)), error(move(e)), exit_code(ec) {}
+        /**
+         * Whether or not the command succeeded, defaults to true.
+         */
+        bool success = true;
         /**
          * Output from stdout.
          */
@@ -204,9 +209,9 @@ namespace leatherman { namespace execution {
          */
         std::string error;
         /**
-         * The process exit code.
+         * The process exit code, defaults to 0.
          */
-        int exit_code;
+        int exit_code = 0;
     };
 
     /**

--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -187,6 +187,29 @@ namespace leatherman { namespace execution {
     };
 
     /**
+     * Encapsulates return value from executing a process.
+     */
+    struct result
+    {
+        /**
+         * Whether or not the command succeeded.
+         */
+        bool success;
+        /**
+         * Output from stdout.
+         */
+        std::string output;
+        /**
+         * Output from stderr (if not redirected).
+         */
+        std::string error;
+        /**
+         * The process exit code.
+         */
+        int exit_code;
+    };
+
+    /**
      * Searches the given paths for the given executable file.
      * @param file The file to search for.
      * @param directories The directories to search.
@@ -207,9 +230,9 @@ namespace leatherman { namespace execution {
      * @param file The name or path of the program to execute.
      * @param timeout The timeout, in seconds.  Defaults to no timeout.
      * @param options The execution options.  Defaults to trimming output, merging the environment, and redirecting stderr to null.
-     * @return Returns a tuple of whether or not the command succeeded, output from stdout, output from stderr (if not redirected), and the exit code.
+     * @return Returns a result struct.
      */
-    std::tuple<bool, std::string, std::string, int> execute(
+    result execute(
         std::string const& file,
         uint32_t timeout = 0,
         lth_util::option_set<execution_options> const& options = { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null });
@@ -220,9 +243,9 @@ namespace leatherman { namespace execution {
      * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @param options The execution options.  Defaults to trimming output, merging the environment, and redirecting stderr to null.
-     * @return Returns a tuple of whether or not the command succeeded, output from stdout, output from stderr (if not redirected), and the exit code.
+     * @return Returns a result struct.
      */
-    std::tuple<bool, std::string, std::string, int> execute(
+    result execute(
         std::string const& file,
         std::vector<std::string> const& arguments,
         uint32_t timeout = 0,
@@ -235,9 +258,9 @@ namespace leatherman { namespace execution {
      * @param environment The environment variables to pass to the child process.
      * @param timeout The timeout, in seconds. Defaults to no timeout.
      * @param options The execution options.  Defaults to trimming output, merging the environment, and redirecting stderr to null.
-     * @return Returns a tuple of whether or not the command succeeded, output from stdout, output from stderr (if not redirected), and the exit code.
+     * @return Returns a result struct.
      */
-    std::tuple<bool, std::string, std::string, int> execute(
+    result execute(
         std::string const& file,
         std::vector<std::string> const& arguments,
         std::map<std::string, std::string> const& environment,

--- a/execution/src/execution.cc
+++ b/execution/src/execution.cc
@@ -136,7 +136,7 @@ namespace leatherman { namespace execution {
         return file + remainder;
     }
 
-    tuple<bool, string, string> execute(
+    tuple<bool, string, string, int> execute(
         string const& file,
         vector<string> const* arguments,
         map<string, string> const* environment,
@@ -157,7 +157,7 @@ namespace leatherman { namespace execution {
         }
     }
 
-    tuple<bool, string, string> execute(
+    tuple<bool, string, string, int> execute(
         string const& file,
         uint32_t timeout,
         option_set<execution_options> const& options)
@@ -168,7 +168,7 @@ namespace leatherman { namespace execution {
         return execute(file, nullptr, nullptr, nullptr, stderr_callback, actual_options, timeout);
     }
 
-    tuple<bool, string, string> execute(
+    tuple<bool, string, string, int> execute(
         string const& file,
         vector<string> const& arguments,
         uint32_t timeout,
@@ -180,7 +180,7 @@ namespace leatherman { namespace execution {
         return execute(file, &arguments, nullptr, nullptr, stderr_callback, actual_options, timeout);
     }
 
-    tuple<bool, string, string> execute(
+    tuple<bool, string, string, int> execute(
         string const& file,
         vector<string> const& arguments,
         map<string, string> const& environment,

--- a/execution/src/execution.cc
+++ b/execution/src/execution.cc
@@ -136,7 +136,7 @@ namespace leatherman { namespace execution {
         return file + remainder;
     }
 
-    tuple<bool, string, string, int> execute(
+    result execute(
         string const& file,
         vector<string> const* arguments,
         map<string, string> const* environment,
@@ -157,7 +157,7 @@ namespace leatherman { namespace execution {
         }
     }
 
-    tuple<bool, string, string, int> execute(
+    result execute(
         string const& file,
         uint32_t timeout,
         option_set<execution_options> const& options)
@@ -168,7 +168,7 @@ namespace leatherman { namespace execution {
         return execute(file, nullptr, nullptr, nullptr, stderr_callback, actual_options, timeout);
     }
 
-    tuple<bool, string, string, int> execute(
+    result execute(
         string const& file,
         vector<string> const& arguments,
         uint32_t timeout,
@@ -180,7 +180,7 @@ namespace leatherman { namespace execution {
         return execute(file, &arguments, nullptr, nullptr, stderr_callback, actual_options, timeout);
     }
 
-    tuple<bool, string, string, int> execute(
+    result execute(
         string const& file,
         vector<string> const& arguments,
         map<string, string> const& environment,
@@ -225,7 +225,7 @@ namespace leatherman { namespace execution {
     {
         auto actual_options = options;
         setup_each_line(stdout_callback, stderr_callback, actual_options);
-        return get<0>(execute(file, nullptr, nullptr, stdout_callback, stderr_callback, actual_options, timeout));
+        return execute(file, nullptr, nullptr, stdout_callback, stderr_callback, actual_options, timeout).success;
     }
 
     bool each_line(
@@ -238,7 +238,7 @@ namespace leatherman { namespace execution {
     {
         auto actual_options = options;
         setup_each_line(stdout_callback, stderr_callback, actual_options);
-        return get<0>(execute(file, &arguments, nullptr, stdout_callback, stderr_callback, actual_options, timeout));
+        return execute(file, &arguments, nullptr, stdout_callback, stderr_callback, actual_options, timeout).success;
     }
 
     bool each_line(
@@ -252,7 +252,7 @@ namespace leatherman { namespace execution {
     {
         auto actual_options = options;
         setup_each_line(stdout_callback, stderr_callback, actual_options);
-        return get<0>(execute(file, &arguments, &environment, stdout_callback, stderr_callback, actual_options, timeout));
+        return execute(file, &arguments, &environment, stdout_callback, stderr_callback, actual_options, timeout).success;
     }
 
     static bool process_data(bool trim, string const& data, string& buffer, string const& logger, function<bool(string&)> const& callback)

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -372,7 +372,7 @@ namespace leatherman { namespace execution {
         return -1;
     }
 
-    tuple<bool, string, string> execute(
+    tuple<bool, string, string, int> execute(
         string const& file,
         vector<string> const* arguments,
         map<string, string> const* environment,
@@ -389,7 +389,7 @@ namespace leatherman { namespace execution {
             if (options[execution_options::throw_on_nonzero_exit]) {
                 throw child_exit_exception("child process returned non-zero exit status.", 127, {}, {});
             }
-            return make_tuple(false, "", "");
+            return make_tuple(false, "", "", 127);
         }
 
         // Create the pipes for stdin/stdout redirection
@@ -530,7 +530,7 @@ namespace leatherman { namespace execution {
                 throw child_signal_exception((boost::format("child process was terminated by signal (%1%).") % status).str(), status, move(output), move(error));
             }
         }
-        return make_tuple(success, move(output), move(error));
+        return make_tuple(success, move(output), move(error), status);
     }
 
 }}  // namespace leatherman::execution

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -372,7 +372,7 @@ namespace leatherman { namespace execution {
         return -1;
     }
 
-    tuple<bool, string, string, int> execute(
+    result execute(
         string const& file,
         vector<string> const* arguments,
         map<string, string> const* environment,
@@ -389,7 +389,7 @@ namespace leatherman { namespace execution {
             if (options[execution_options::throw_on_nonzero_exit]) {
                 throw child_exit_exception("child process returned non-zero exit status.", 127, {}, {});
             }
-            return make_tuple(false, "", "", 127);
+            return {false, "", "", 127};
         }
 
         // Create the pipes for stdin/stdout redirection
@@ -530,7 +530,7 @@ namespace leatherman { namespace execution {
                 throw child_signal_exception((boost::format("child process was terminated by signal (%1%).") % status).str(), status, move(output), move(error));
             }
         }
-        return make_tuple(success, move(output), move(error), status);
+        return {success, move(output), move(error), status};
     }
 
 }}  // namespace leatherman::execution

--- a/execution/src/windows/execution.cc
+++ b/execution/src/windows/execution.cc
@@ -347,7 +347,7 @@ namespace leatherman { namespace execution {
         }
     }
 
-    tuple<bool, string, string> execute(
+    tuple<bool, string, string, int> execute(
         string const& file,
         vector<string> const* arguments,
         map<string, string> const* environment,
@@ -380,7 +380,7 @@ namespace leatherman { namespace execution {
             if (options[execution_options::throw_on_nonzero_exit]) {
                 throw child_exit_exception("child process returned non-zero exit status.", 127, {}, {});
             }
-            return make_tuple(false, "", "");
+            return make_tuple(false, "", "", 127);
         }
 
         // Setup the execution environment
@@ -594,7 +594,7 @@ namespace leatherman { namespace execution {
         if (exit_code != 0 && options[execution_options::throw_on_nonzero_exit]) {
             throw child_exit_exception("child process returned non-zero exit status.", exit_code, output, error);
         }
-        return make_tuple(exit_code == 0, move(output), move(error));
+        return make_tuple(exit_code == 0, move(output), move(error), exit_code);
     }
 
 }}  // namespace leatherman::execution

--- a/execution/src/windows/execution.cc
+++ b/execution/src/windows/execution.cc
@@ -347,7 +347,7 @@ namespace leatherman { namespace execution {
         }
     }
 
-    tuple<bool, string, string, int> execute(
+    result execute(
         string const& file,
         vector<string> const* arguments,
         map<string, string> const* environment,
@@ -380,7 +380,7 @@ namespace leatherman { namespace execution {
             if (options[execution_options::throw_on_nonzero_exit]) {
                 throw child_exit_exception("child process returned non-zero exit status.", 127, {}, {});
             }
-            return make_tuple(false, "", "", 127);
+            return {false, "", "", 127};
         }
 
         // Setup the execution environment
@@ -594,7 +594,7 @@ namespace leatherman { namespace execution {
         if (exit_code != 0 && options[execution_options::throw_on_nonzero_exit]) {
             throw child_exit_exception("child process returned non-zero exit status.", exit_code, output, error);
         }
-        return make_tuple(exit_code == 0, move(output), move(error), exit_code);
+        return {exit_code == 0, move(output), move(error), static_cast<int>(exit_code)};
     }
 
 }}  // namespace leatherman::execution

--- a/execution/tests/windows/execution.cc
+++ b/execution/tests/windows/execution.cc
@@ -99,44 +99,41 @@ SCENARIO("executing commands with execution::execute") {
         });
         return variables;
     };
-    bool success = false;
-    string output, error;
-    int exit_code;
     GIVEN("a command that succeeds") {
         THEN("the output should be returned") {
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file3.txt") });
-            REQUIRE(success);
-            REQUIRE(output == "file3");
-            REQUIRE(error == "");
-            REQUIRE(exit_code == 0);
+            auto exec = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file3.txt") });
+            REQUIRE(exec.success);
+            REQUIRE(exec.output == "file3");
+            REQUIRE(exec.error == "");
+            REQUIRE(exec.exit_code == 0);
         }
     }
     GIVEN("a command that fails") {
         WHEN("default options are used") {
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" });
+            auto exec = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" });
             THEN("no output is returned") {
-                REQUIRE_FALSE(success);
-                REQUIRE(output == "");
-                REQUIRE(error == "");
-                REQUIRE(exit_code > 0);
+                REQUIRE_FALSE(exec.success);
+                REQUIRE(exec.output == "");
+                REQUIRE(exec.error == "");
+                REQUIRE(exec.exit_code > 0);
             }
         }
         WHEN("the redirect stderr option is used") {
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_stdout });
+            auto exec = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_stdout });
             THEN("error output is returned on stdout") {
-                REQUIRE_FALSE(success);
-                REQUIRE(output == "File Not Found");
-                REQUIRE(error == "");
-                REQUIRE(exit_code > 0);
+                REQUIRE_FALSE(exec.success);
+                REQUIRE(exec.output == "File Not Found");
+                REQUIRE(exec.error == "");
+                REQUIRE(exec.exit_code > 0);
             }
         }
         WHEN("not redirecting stderr to null") {
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment });
+            auto exec = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment });
             THEN("error output is returned") {
-                REQUIRE_FALSE(success);
-                REQUIRE(output == "");
-                REQUIRE(error == "File Not Found");
-                REQUIRE(exit_code > 0);
+                REQUIRE_FALSE(exec.success);
+                REQUIRE(exec.output == "");
+                REQUIRE(exec.error == "File Not Found");
+                REQUIRE(exec.exit_code > 0);
             }
         }
         WHEN("the 'throw on non-zero exit' option is used") {
@@ -146,11 +143,11 @@ SCENARIO("executing commands with execution::execute") {
         }
         WHEN("requested to merge the environment") {
             SetEnvironmentVariableW(L"TEST_INHERITED_VARIABLE", L"TEST_INHERITED_VALUE");
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "set" }, { { "TEST_VARIABLE1", "TEST_VALUE1" }, { "TEST_VARIABLE2", "TEST_VALUE2" } });
+            auto exec = execute("cmd.exe", { "/c", "set" }, { { "TEST_VARIABLE1", "TEST_VALUE1" }, { "TEST_VARIABLE2", "TEST_VALUE2" } });
             SetEnvironmentVariableW(L"TEST_INHERITED_VARIABLE", nullptr);
-            REQUIRE(success);
-            REQUIRE(error == "");
-            auto variables = get_variables(output);
+            REQUIRE(exec.success);
+            REQUIRE(exec.error == "");
+            auto variables = get_variables(exec.output);
             THEN("the child environment should contain the given variables") {
                 REQUIRE(variables.size() > 4u);
                 REQUIRE(variables.count("TEST_VARIABLE1") == 1u);
@@ -167,11 +164,11 @@ SCENARIO("executing commands with execution::execute") {
         }
         WHEN("requested to override the environment") {
             SetEnvironmentVariableW(L"TEST_INHERITED_VARIABLE", L"TEST_INHERITED_VALUE");
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "set" }, { { "TEST_VARIABLE1", "TEST_VALUE1" }, { "TEST_VARIABLE2", "TEST_VALUE2" } }, 0, { execution_options::trim_output });
+            auto exec = execute("cmd.exe", { "/c", "set" }, { { "TEST_VARIABLE1", "TEST_VALUE1" }, { "TEST_VARIABLE2", "TEST_VALUE2" } }, 0, { execution_options::trim_output });
             SetEnvironmentVariableW(L"TEST_INHERITED_VARIABLE", nullptr);
-            REQUIRE(success);
-            REQUIRE(error == "");
-            auto variables = get_variables(output);
+            REQUIRE(exec.success);
+            REQUIRE(exec.error == "");
+            auto variables = get_variables(exec.output);
             THEN("the child environment should only contain the given variables") {
                 REQUIRE(variables.count("TEST_VARIABLE1") == 1u);
                 REQUIRE(variables["TEST_VARIABLE1"] == "TEST_VALUE1");
@@ -186,10 +183,10 @@ SCENARIO("executing commands with execution::execute") {
             }
         }
         WHEN("requested to override LC_ALL or LANG") {
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "set" }, { { "LANG", "FOO" }, { "LC_ALL", "BAR" } });
-            REQUIRE(success);
-            REQUIRE(error == "");
-            auto variables = get_variables(output);
+            auto exec = execute("cmd.exe", { "/c", "set" }, { { "LANG", "FOO" }, { "LC_ALL", "BAR" } });
+            REQUIRE(exec.success);
+            REQUIRE(exec.error == "");
+            auto variables = get_variables(exec.output);
             THEN("the values should be passed to the child process") {
                 REQUIRE(variables.count("LC_ALL") == 1u);
                 REQUIRE(variables["LC_ALL"] == "BAR");
@@ -200,17 +197,17 @@ SCENARIO("executing commands with execution::execute") {
     }
     GIVEN("a command that outputs leading/trailing whitespace") {
         THEN("whitespace should be trimmed by default") {
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file1.txt") });
-            REQUIRE(success);
-            REQUIRE(output == "this is a test of trimming");
-            REQUIRE(error == "");
+            auto exec = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file1.txt") });
+            REQUIRE(exec.success);
+            REQUIRE(exec.output == "this is a test of trimming");
+            REQUIRE(exec.error == "");
         }
         WHEN("the 'trim whitespace' option is not used") {
-            tie(success, output, error, exit_code) = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file1.txt") }, 0, { execution_options::merge_environment });
-            REQUIRE(success);
+            auto exec = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file1.txt") }, 0, { execution_options::merge_environment });
+            REQUIRE(exec.success);
             THEN("whitespace should not be trimmed") {
-                REQUIRE(output == "   this is a test of trimming   ");
-                REQUIRE(error == "");
+                REQUIRE(exec.output == "   this is a test of trimming   ");
+                REQUIRE(exec.error == "");
             }
         }
     }
@@ -238,10 +235,10 @@ SCENARIO("executing commands with execution::execute") {
     GIVEN("stderr is redirected to null") {
         WHEN("using a debug log level") {
             log_capture capture(log_level::debug);
-            tie(success, output, error, exit_code) = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat");
-            REQUIRE(success);
-            REQUIRE(output == "foo=bar");
-            REQUIRE(error.empty());
+            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat");
+            REQUIRE(exec.success);
+            REQUIRE(exec.output == "foo=bar");
+            REQUIRE(exec.error.empty());
             THEN("stderr is logged") {
                 auto output = capture.result();
                 CAPTURE(output);
@@ -250,10 +247,10 @@ SCENARIO("executing commands with execution::execute") {
         }
         WHEN("not using a debug log level") {
             log_capture capture(log_level::warning);
-            tie(success, output, error, exit_code) = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat");
-            REQUIRE(success);
-            REQUIRE(output == "foo=bar");
-            REQUIRE(error.empty());
+            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat");
+            REQUIRE(exec.success);
+            REQUIRE(exec.output == "foo=bar");
+            REQUIRE(exec.error.empty());
             THEN("stderr is not logged") {
                 auto output = capture.result();
                 CAPTURE(output);

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -472,8 +472,9 @@ namespace leatherman { namespace ruby {
 
         bool success;
         string output, none;
+        int exit_code;
 
-        tie(success, output, none) = execute(ruby, { "-e", "print(['libdir', 'archlibdir', 'sitearchlibdir', 'bindir'].find do |name|"
+        tie(success, output, none, exit_code) = execute(ruby, { "-e", "print(['libdir', 'archlibdir', 'sitearchlibdir', 'bindir'].find do |name|"
                                                                   "dir = RbConfig::CONFIG[name];"
                                                                   "next unless dir;"
                                                                   "file = File.join(dir, RbConfig::CONFIG['LIBRUBY_SO']);"

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -470,28 +470,24 @@ namespace leatherman { namespace ruby {
         }
         LOG_DEBUG("ruby was found at \"%1%\".", ruby);
 
-        bool success;
-        string output, none;
-        int exit_code;
-
-        tie(success, output, none, exit_code) = execute(ruby, { "-e", "print(['libdir', 'archlibdir', 'sitearchlibdir', 'bindir'].find do |name|"
-                                                                  "dir = RbConfig::CONFIG[name];"
-                                                                  "next unless dir;"
-                                                                  "file = File.join(dir, RbConfig::CONFIG['LIBRUBY_SO']);"
-                                                                  "break file if File.exist? file;"
-                                                                  "false end)" });
-        if (!success) {
-            LOG_WARNING("ruby failed to run: %1%", output);
+        auto exec = execute(ruby, { "-e", "print(['libdir', 'archlibdir', 'sitearchlibdir', 'bindir'].find do |name|"
+                "dir = RbConfig::CONFIG[name];"
+                "next unless dir;"
+                "file = File.join(dir, RbConfig::CONFIG['LIBRUBY_SO']);"
+                "break file if File.exist? file;"
+                "false end)" });
+        if (!exec.success) {
+            LOG_WARNING("ruby failed to run: %1%", exec.output);
             return library;
         }
 
         boost::system::error_code ec;
-        if (!exists(output, ec) || is_directory(output, ec)) {
-            LOG_DEBUG("ruby library \"%1%\" was not found: ensure ruby was built with the --enable-shared configuration option.", output);
+        if (!exists(exec.output, ec) || is_directory(exec.output, ec)) {
+            LOG_DEBUG("ruby library \"%1%\" was not found: ensure ruby was built with the --enable-shared configuration option.", exec.output);
             return library;
         }
 
-        library.load(output);
+        library.load(exec.output);
         return library;
     }
 


### PR DESCRIPTION
The execute commands previously had no way to return the exit code from
the child process without throwing an exception. Many use cases include
examining the exit code of a failed child process as normal behavior, so
we should provide a way to get it without using exceptions. Add it to
the return tuple to make it available to callers.