### PR TITLE
(maint) Fix log level to display input string

### DIFF
--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -187,7 +187,7 @@ namespace leatherman { namespace logging {
                 return in;
             }
         }
-        throw runtime_error((boost::format("invalid log level '%1%': expected none, trace, debug, info, warn, error, or fatal.") % level).str());
+        throw runtime_error((boost::format("invalid log level '%1%': expected none, trace, debug, info, warn, error, or fatal.") % value).str());
     }
 
     ostream& operator<<(ostream& strm, log_level level)


### PR DESCRIPTION
The log_level error message for unparseable values was
returning the unset log_level rather than the input string.