### PR TITLE
[BLOCKED] (CTH-378) Rotate log files

### DIFF
--- a/logging/inc/leatherman/logging/logging.hpp
+++ b/logging/inc/leatherman/logging/logging.hpp
@@ -154,6 +154,26 @@ namespace leatherman { namespace logging {
     void setup_logging(std::ostream &dst, std::string locale = "");
 
     /**
+     * Sets up logging; it will write records to the specified file.
+     * Log file rotation will be configured by file size as follows.
+     * The logging level is set to warning by default.
+     * @param file_name File name pattern and path; ex. '/var/log/my_app_%3N.log'.
+     * @param open_mode File open mode; ex. 'std::ios_base::app'.
+     * @param target Path of the directory where rotated files will be stored.
+     * @param rotation_size Max file size, after which it rotates (num chars).
+     * @param max_size Max size for all rotated files (in bytes).
+     * @param min_free_space Min drive space, to prevent logging (in bytes).
+     * @param locale The locale identifier to use for logging.
+     */
+    void setup_logging(std::string file_name,
+                       std::ios_base::openmode open_mode,
+                       std::string target,
+                       int rotation_size,
+                       int max_size,
+                       int min_free_space,
+                       std::string locale = "");
+
+    /**
      * Sets the current log level.
      * @param level The new current log level to set.
      */
@@ -167,6 +187,7 @@ namespace leatherman { namespace logging {
 
     /**
      * Sets whether or not log output is colorized.
+     * If logging was configured to file, colorization will be ignored on Windows.
      * @param color Pass true if log output is colorized or false if it is not colorized.
      */
     void set_colorization(bool color);
@@ -257,12 +278,20 @@ namespace leatherman { namespace logging {
     }
 
     /**
-     * Starts colorizing for the given log level.
+     * Starts colorizing the output stream for the given log level.
      * This is a no-op on platforms that don't natively support terminal colors.
      * @param dst The stream to colorize.
      * @param level The log level to colorize for. Defaults to none, which resets colorization.
      */
     void colorize(std::ostream &dst, log_level level = log_level::none);
+
+    /**
+     * Starts colorizing the formatting output stream for the given log level.
+     * This is a no-op on platforms that don't natively support terminal colors.
+     * @param strm The formatting output stream stream to colorize.
+     * @param level The log level to colorize for. Defaults to none, which resets colorization.
+     */
+    void colorize(boost::log::formatting_ostream& strm, log_level level = log_level::none);
 
     /**
      * Returns whether terminal colors are supported.

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -1,6 +1,7 @@
 #include <leatherman/logging/logging.hpp>
 #include <leatherman/locale/locale.hpp>
 #include <vector>
+#include <locale>
 
 // boost includes are not always warning-clean. Disable warnings that
 // cause problems before including the headers, then re-enable the warnings.
@@ -18,6 +19,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem/path.hpp>
 
 #pragma GCC diagnostic pop
 
@@ -119,6 +121,11 @@ namespace leatherman { namespace logging {
                        int min_free_space,
                        std::string locale)
     {
+        // Initialize locale to default before boost::log in order to avoid
+        // crashes during process termination due to file sinks; refer to
+        // www.boost.org/doc/libs/1_59_0/libs/log/doc/html/log/rationale/why_crash_on_term.html
+        boost::filesystem::path::imbue(std::locale("C"));
+
         // Use the text file as logging backend, in order to set file rotation
         using backend_t = sinks::text_file_backend;
         boost::shared_ptr<backend_t> backend(

--- a/logging/src/posix/logging.cc
+++ b/logging/src/posix/logging.cc
@@ -6,7 +6,8 @@ using namespace std;
 
 namespace leatherman { namespace logging {
 
-    void colorize(ostream& dst, log_level level)
+    template <typename StreamT>
+    void colorize_impl(StreamT& strm, log_level level)
     {
         if (!get_colorization()) {
             return;
@@ -19,16 +20,26 @@ namespace leatherman { namespace logging {
         static const string reset = "\33[0m";
 
         if (level == log_level::trace || level == log_level::debug) {
-            dst << cyan;
+            strm << cyan;
         } else if (level == log_level::info) {
-            dst << green;
+            strm << green;
         } else if (level == log_level::warning) {
-            dst << yellow;
+            strm << yellow;
         } else if (level == log_level::error || level == log_level::fatal) {
-            dst << red;
+            strm << red;
         } else {
-            dst << reset;
+            strm << reset;
         }
+    }
+
+    void colorize(ostream& dst, log_level level)
+    {
+        colorize_impl(dst, level);
+    }
+
+    void colorize(boost::log::formatting_ostream& strm, log_level level)
+    {
+        colorize_impl(strm, level);
     }
 
     bool color_supported(ostream& dst)

--- a/logging/src/windows/logging.cc
+++ b/logging/src/windows/logging.cc
@@ -30,6 +30,11 @@ namespace leatherman { namespace logging {
         }
     }
 
+    void colorize(boost::log::formatting_ostream& strm, log_level level)
+    {
+        return;
+    }
+
     bool color_supported(ostream& dst)
     {
         bool colorize = false;


### PR DESCRIPTION
Enable log file rotation by using the text_file_backend as the backend
sink of boost log. Log file rotation will be performed by file size.