### PR TITLE
(maint) Use ctor call instead of empty init list in execute signature

### DIFF
--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -347,7 +347,7 @@ namespace leatherman { namespace execution {
         std::string const& input,
         std::string const& out_file,
         std::string const& err_file = "",
-        std::map<std::string, std::string> const& environment = {},
+        std::map<std::string, std::string> const& environment = std::map<std::string, std::string>(),
         std::function<void(size_t)> pid_callback = nullptr,
         uint32_t timeout = 0,
         lth_util::option_set<execution_options> const& options = { execution_options::trim_output, execution_options::merge_environment });


### PR DESCRIPTION
Here we try to fix a compilation issue with the signature of a variant
of execution::execute where the env map is defined by default to an
empty initiialization list; we replace that with an explicit call to the
default ctor.