### PR TITLE
Bugfixes for using leatherman as a standalone installed library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ endif()
 if (LEATHERMAN_INSTALL)
     set(CMAKE_FILES
         cmake/cflags.cmake
+        cmake/GetGitRevisionDescription.cmake
+        cmake/GetGitRevisionDescription.cmake.in
         cmake/leatherman.cmake
         cmake/options.cmake
         cmake/leatherman_config.cmake

--- a/curl/CMakeLists.txt
+++ b/curl/CMakeLists.txt
@@ -32,15 +32,18 @@ add_leatherman_headers(inc/leatherman)
 
 add_leatherman_test(tests/client_test.cc tests/request_test.cc tests/response_test.cc)
 
-# Create a mock curl library; it needs to be separate to allow for dllimport in the client source
-if (CURL_STATIC)
-    set(CURL_LINK STATIC)
-else()
-    set(CURL_LINK SHARED)
-endif()
-add_library(mock_curl ${CURL_LINK} tests/mock_curl.cc)
-set_target_properties(mock_curl PROPERTIES COMPILE_FLAGS "${LEATHERMAN_CXX_FLAGS}")
+if (BUILDING_LEATHERMAN)
 
-if (COVERALLS)
-    target_link_libraries(mock_curl gcov)
+    # Create a mock curl library; it needs to be separate to allow for dllimport in the client source
+    if (CURL_STATIC)
+        set(CURL_LINK STATIC)
+    else()
+        set(CURL_LINK SHARED)
+    endif()
+    add_library(mock_curl ${CURL_LINK} tests/mock_curl.cc)
+    set_target_properties(mock_curl PROPERTIES COMPILE_FLAGS "${LEATHERMAN_CXX_FLAGS}")
+
+    if (COVERALLS)
+        target_link_libraries(mock_curl gcov)
+    endif()
 endif()

--- a/dynamic_library/CMakeLists.txt
+++ b/dynamic_library/CMakeLists.txt
@@ -22,13 +22,16 @@ endif()
 
 add_leatherman_test(tests/dynamic_library_tests.cc)
 
-#Build dummy dynamic libraries for use in testing
-add_library(libtest SHARED tests/test-lib/hello.cc)
-set_target_properties(libtest PROPERTIES PREFIX "" SUFFIX ".so")
-add_library(libtest1 SHARED tests/test-lib/hello.cc tests/test-lib/goodbye.cc)
-set_target_properties(libtest1 PROPERTIES PREFIX "" SUFFIX ".so")
+if (BUILDING_LEATHERMAN)
 
-configure_file (
-    "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp.in"
-    "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp"
-)
+    #Build dummy dynamic libraries for use in testing
+    add_library(libtest SHARED tests/test-lib/hello.cc)
+    set_target_properties(libtest PROPERTIES PREFIX "" SUFFIX ".so")
+    add_library(libtest1 SHARED tests/test-lib/hello.cc tests/test-lib/goodbye.cc)
+    set_target_properties(libtest1 PROPERTIES PREFIX "" SUFFIX ".so")
+
+    configure_file (
+        "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp.in"
+        "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp"
+    )
+endif()

--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -23,18 +23,21 @@ if(WIN32)
 else()
     set(PLATFORM_TESTS tests/posix/execution.cc)
 endif()
+
 add_leatherman_test(tests/log_capture.cc ${PLATFORM_TESTS})
 
-# Dumb implementation of cat.exe for testing stdin/stdout/stderr handling.
-include_directories(${LEATHERMAN_NOWIDE_INCLUDE})
-add_executable(lth_cat tests/lth_cat.cc)
-target_link_libraries(lth_cat ${LEATHERMAN_NOWIDE_LIBS})
-if (COVERALLS)
-    target_link_libraries(lth_cat gcov)
-endif()
-set_target_properties(lth_cat PROPERTIES COMPILE_FLAGS "${LEATHERMAN_CXX_FLAGS}")
+if (BUILDING_LEATHERMAN)
+    # Dumb implementation of cat.exe for testing stdin/stdout/stderr handling.
+    include_directories(${LEATHERMAN_NOWIDE_INCLUDE})
+    add_executable(lth_cat tests/lth_cat.cc)
+    target_link_libraries(lth_cat ${LEATHERMAN_NOWIDE_LIBS})
+    if (COVERALLS)
+        target_link_libraries(lth_cat gcov)
+    endif()
+    set_target_properties(lth_cat PROPERTIES COMPILE_FLAGS "${LEATHERMAN_CXX_FLAGS}")
 
-configure_file (
-    "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp.in"
-    "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp"
-)
+    configure_file (
+        "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp.in"
+        "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp"
+    )
+endif()


### PR DESCRIPTION
The official recommendation from @branan is to install leatherman to the system and build from there, but some testing logic was assuming that leatherman was being used as a vendor library and some cmake files weren't being installed to system locations. This pull request fixes the needful.