### PR TITLE
(maint) Remove ambiguity when building Leatherman with GCC 5 on Windows.

### DIFF
--- a/dynamic_library/src/windows/dynamic_library.cc
+++ b/dynamic_library/src/windows/dynamic_library.cc
@@ -23,7 +23,7 @@ namespace leatherman { namespace dynamic_library {
         // the Tool Help library.
         HANDLE hModuleSnap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, GetCurrentProcessId());
         if (hModuleSnap == INVALID_HANDLE_VALUE) {
-            LOG_DEBUG("library matching pattern %1% not found, CreateToolhelp32Snapshot failed: %2%.", pattern.c_str(), system_error());
+            LOG_DEBUG("library matching pattern %1% not found, CreateToolhelp32Snapshot failed: %2%.", pattern.c_str(), windows::system_error());
             return library;
         }
         scoped_resource<HANDLE> hModSnap(hModuleSnap, CloseHandle);
@@ -31,7 +31,7 @@ namespace leatherman { namespace dynamic_library {
         MODULEENTRY32 me32 = {};
         me32.dwSize = sizeof(MODULEENTRY32);
         if (!Module32First(hModSnap, &me32)) {
-            LOG_DEBUG("library matching pattern %1% not found, Module32First failed: %2%.", pattern.c_str(), system_error());
+            LOG_DEBUG("library matching pattern %1% not found, Module32First failed: %2%.", pattern.c_str(), windows::system_error());
             return library;
         }
 
@@ -73,7 +73,7 @@ namespace leatherman { namespace dynamic_library {
             // Load now
             hMod = LoadLibraryW(wname.c_str());
             if (!hMod) {
-                LOG_DEBUG("library %1% not found %2%.", name.c_str(), system_error());
+                LOG_DEBUG("library %1% not found %2%.", name.c_str(), windows::system_error());
                 return false;
             }
             _first_load = true;

--- a/execution/src/windows/execution.cc
+++ b/execution/src/windows/execution.cc
@@ -141,7 +141,7 @@ namespace leatherman { namespace execution {
             &attributes));
 
         if (read_handle == INVALID_HANDLE_VALUE) {
-            LOG_ERROR("failed to create read pipe: %1%.", system_error());
+            LOG_ERROR("failed to create read pipe: %1%.", windows::system_error());
             throw execution_exception("failed to create read pipe.");
         }
 
@@ -156,7 +156,7 @@ namespace leatherman { namespace execution {
             nullptr));
 
         if (write_handle == INVALID_HANDLE_VALUE) {
-            LOG_ERROR("failed to create write pipe: %1%.", system_error());
+            LOG_ERROR("failed to create write pipe: %1%.", windows::system_error());
             throw execution_exception("failed to create write pipe.");
         }
 
@@ -248,7 +248,7 @@ namespace leatherman { namespace execution {
             if (handle != INVALID_HANDLE_VALUE) {
                 event = scoped_handle(CreateEvent(nullptr, TRUE, FALSE, nullptr));
                 if (!event) {
-                    LOG_ERROR("failed to create %1% read event: %2%.", name, system_error());
+                    LOG_ERROR("failed to create %1% read event: %2%.", name, windows::system_error());
                     throw execution_exception("failed to create read event.");
                 }
                 overlapped.hEvent = event;
@@ -296,7 +296,7 @@ namespace leatherman { namespace execution {
                             pipe.pending = true;
                             break;
                         }
-                        LOG_ERROR("%1% pipe i/o failed: %2%.", pipe.name, system_error());
+                        LOG_ERROR("%1% pipe i/o failed: %2%.", pipe.name, windows::system_error());
                         throw execution_exception("child i/o failed.");
                     }
 
@@ -341,7 +341,7 @@ namespace leatherman { namespace execution {
             // Wait for data (and, optionally, timeout)
             auto result = WaitForMultipleObjects(wait_handles.size(), wait_handles.data(), FALSE, INFINITE);
             if (result >= (WAIT_OBJECT_0 + wait_handles.size())) {
-                LOG_ERROR("failed to wait for child process i/o: %1%.", system_error());
+                LOG_ERROR("failed to wait for child process i/o: %1%.", windows::system_error());
                 throw execution_exception("failed to wait for child process i/o.");
             }
 
@@ -364,7 +364,7 @@ namespace leatherman { namespace execution {
                 DWORD count = 0;
                 if (!GetOverlappedResult(pipe.handle, &pipe.overlapped, &count, FALSE)) {
                     if (GetLastError() != ERROR_BROKEN_PIPE) {
-                        LOG_ERROR("asynchronous i/o on %1% failed: %2%.", pipe.name, system_error());
+                        LOG_ERROR("asynchronous i/o on %1% failed: %2%.", pipe.name, windows::system_error());
                         throw execution_exception("asynchronous i/o failed.");
                     }
                     // Treat a broken pipe as nothing left to read
@@ -543,7 +543,7 @@ namespace leatherman { namespace execution {
             NULL,           /* Use existing current directory */
             &startupInfo,   /* STARTUPINFO for child process */
             &procInfo)) {   /* PROCESS_INFORMATION pointer for output */
-            LOG_ERROR("failed to create process: %1%.", system_error());
+            LOG_ERROR("failed to create process: %1%.", windows::system_error());
             throw execution_exception("failed to create child process.");
         }
 
@@ -564,10 +564,10 @@ namespace leatherman { namespace execution {
         if (use_job_object) {
             hJob = scoped_handle(CreateJobObjectW(nullptr, nullptr));
             if (hJob == NULL) {
-                LOG_ERROR("failed to create job object: %1%.", system_error());
+                LOG_ERROR("failed to create job object: %1%.", windows::system_error());
                 throw execution_exception("failed to create job object.");
             } else if (!AssignProcessToJobObject(hJob, hProcess)) {
-                LOG_ERROR("failed to associate process with job object: %1%.", system_error());
+                LOG_ERROR("failed to associate process with job object: %1%.", windows::system_error());
                 throw execution_exception("failed to associate process with job object.");
             }
         }
@@ -578,7 +578,7 @@ namespace leatherman { namespace execution {
                 // Terminate the process on an exception
                 if (use_job_object) {
                     if (!TerminateJobObject(hJob, -1)) {
-                        LOG_ERROR("failed to terminate process: %1%.", system_error());
+                        LOG_ERROR("failed to terminate process: %1%.", windows::system_error());
                     }
                 } else {
                     LOG_WARNING("could not terminate process %1% because a job object could not be used.", procInfo.dwProcessId);
@@ -591,7 +591,7 @@ namespace leatherman { namespace execution {
         if (timeout) {
             timer = scoped_handle(CreateWaitableTimer(nullptr, TRUE, nullptr));
             if (!timer) {
-                LOG_ERROR("failed to create waitable timer: %1%.", system_error());
+                LOG_ERROR("failed to create waitable timer: %1%.", windows::system_error());
                 throw execution_exception("failed to create waitable timer.");
             }
 
@@ -600,7 +600,7 @@ namespace leatherman { namespace execution {
             LARGE_INTEGER future;
             future.QuadPart = timeout * -10000000ll;
             if (!SetWaitableTimer(timer, &future, 0, nullptr, nullptr, FALSE)) {
-                LOG_ERROR("failed to set waitable timer: %1%.", system_error());
+                LOG_ERROR("failed to set waitable timer: %1%.", windows::system_error());
                 throw execution_exception("failed to set waitable timer.");
             }
         }
@@ -631,7 +631,7 @@ namespace leatherman { namespace execution {
             // Timeout while waiting on the process to complete
             throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str(), static_cast<size_t>(procInfo.dwProcessId));
         } else {
-            LOG_ERROR("failed to wait for child process to terminate: %1%.", system_error());
+            LOG_ERROR("failed to wait for child process to terminate: %1%.", windows::system_error());
             throw execution_exception("failed to wait for child process to terminate.");
         }
 


### PR DESCRIPTION
The stdlib that comes with GCC 5.2 on Windows declares `std::system_error`
(C++11 exception type).  This conflicts with
`leatherman::windows::system_error` in a few places.

This simply partially qualifies the `system_error` uses so that it resolves the
ambiguity.
