### PR TITLE
(maint) Remove redundant move invocation in construction of ruby api instance

### DIFF
--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -113,7 +113,7 @@ namespace leatherman { namespace ruby {
 
     api& api::instance()
     {
-        static api instance { move(create()) };
+        static api instance { create() };
         return instance;
     }
 


### PR DESCRIPTION
The move was causing Clang to emit a warning (which we treat as an error due to -Werror). Removing it makes everything better.