### PR TITLE
(maint) Fix compilation on Windows with GCC 5.2.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ install:
   - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
   - SET PATH=C:\Ruby21-x64\bin;C:\tools\mingw64\bin;%PATH%
+  - ps: $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
+  - ps: $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
 
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
   - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
@@ -14,9 +16,7 @@ install:
   - ps: 7z.exe x "curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
 
 build_script:
-  - ps: mv "C:\Program Files (x86)\Git\bin\sh.exe" "C:\Program Files (x86)\Git\bin\shxx.exe"
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON .
-  - ps: mv "C:\Program Files (x86)\Git\bin\shxx.exe" "C:\Program Files (x86)\Git\bin\sh.exe"
   - ps: mingw32-make
 
 test_script:

--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -46,6 +46,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         set(LEATHERMAN_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} -Wextra")
     endif()
 
+    # On Windows with GCC 5.2.0, disable deprecated declarations because it causes warnings with Boost's use of auto_ptr
+    if (WIN32)
+        set(LEATHERMAN_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} -Wno-deprecated-declarations")
+    endif()
+
     # On unix systems we want to be sure to specify -fPIC for libraries
     if (NOT WIN32)
         set(LEATHERMAN_LIBRARY_FLAGS "-fPIC -nostdlib -nodefaultlibs")
@@ -73,7 +78,8 @@ if (WIN32)
     set(LEATHERMAN_DEFINITIONS -DUNICODE -D_UNICODE -DSECURITY_WIN32)
 endif()
 
-list(APPEND LEATHERMAN_DEFINITIONS -DBOOST_LOG_WITHOUT_WCHAR_T)
+# Enforce UTF-8 in Leatherman.Logging; disable deprecated names in Boost.System to avoid warnings on Windows.
+list(APPEND LEATHERMAN_DEFINITIONS -DBOOST_LOG_WITHOUT_WCHAR_T -DBOOST_SYSTEM_NO_DEPRECATED)
 
 if (NOT BOOST_STATIC)
     # Boost.Log requires that BOOST_LOG_DYN_LINK is set when using dynamic linking. We set ALL for consistency.


### PR DESCRIPTION
GCC 5 introduced -deprecated-declarations, which flags Boost's use of
auto_ptr. Disable for now until Boost updates to remove auto_ptr.

Deprecated APIs in Boost.System cause unused variable warnings in GCC
5.2.0. Disable the deprecated APIs.