### PR TITLE
(maint) Fix install of libnowide.dll

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 
 build_script:
   - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON .
-  - ps: mingw32-make
+  - ps: mingw32-make install
 
 test_script:
   - ps: ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }

--- a/nowide/CMakeLists.txt
+++ b/nowide/CMakeLists.txt
@@ -12,18 +12,19 @@ if (BUILDING_LEATHERMAN)
     set(BOOST_NOWIDE_SKIP_INSTALL ON CACHE BOOL "Disable installing Boost.Nowide")
 
     # have to specify a bindir since this isn't actually a subdirectory of us
-    add_subdirectory("../vendor/boost-nowide" "../vendor/boost-nowide")
+    set(srcdir "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/boost-nowide")
+    set(bindir "${CMAKE_CURRENT_BINARY_DIR}/../vendor/boost-nowide")
+    add_subdirectory(${srcdir} ${bindir})
 
     if (LEATHERMAN_INSTALL)
-        install(DIRECTORY "../vendor/boost-nowide/boost" DESTINATION "include/leatherman/vendor/boost-nowide")
+        install(DIRECTORY "${srcdir}/boost" DESTINATION "include/leatherman/vendor/boost-nowide")
 
         if (WIN32)
-            set(bindir "${CMAKE_CURRENT_BINARY_DIR}/../vendor/boost-nowide")
             # Have to install as FILES instead of TARGETS because the
             # target isn't in this CMake file
             get_target_property(output_name nowide-shared OUTPUT_NAME)
             install(FILES "${bindir}/${CMAKE_IMPORT_LIBRARY_PREFIX}${output_name}${CMAKE_IMPORT_LIBRARY_SUFFIX}" DESTINATION "lib/leatherman")
-            install(FILES "${bindir}/${CMAKE_SHARED_LIBRARY_PREFIX}${output_name}${CMAKE_SHARED_LIBRARY_SUFFIX}" DESTINATION "bin")
+            install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_SHARED_LIBRARY_PREFIX}${output_name}${CMAKE_SHARED_LIBRARY_SUFFIX}" DESTINATION "bin")
         endif()
     endif()
 else()


### PR DESCRIPTION
Previously `make install` on Windows didn't work because it would look
for libnowide.dll on the wrong location. Fix the lookup location and
ensure Windows tests `make install`.