### PR TITLE
(maint) Install cpplint.py when installing leatherman

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,4 +99,6 @@ if (LEATHERMAN_INSTALL)
     configure_file(LeathermanConfig.cmake.in "${PROJECT_BINARY_DIR}/LeathermanConfig.cmake" @ONLY)
     install(FILES "${PROJECT_BINARY_DIR}/LeathermanConfig.cmake" DESTINATION "lib/cmake/leatherman")
     install(EXPORT LeathermanLibraries DESTINATION "lib/cmake/leatherman")
+
+    install(FILES "scripts/cpplint.py" DESTINATION "lib/cmake/leatherman/scripts/")
 endif()


### PR DESCRIPTION
We were omitting the cpplint.py script, which meant that `make cpplint`
would only work with a vendored leatherman install. This commit resolves
this by installing that script during installation.