### PR TITLE
(maint) Simplify nowide compilation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - ps: 7z.exe x "curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
 
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON .
   - ps: mingw32-make install
 
 test_script:

--- a/nowide/CMakeLists.txt
+++ b/nowide/CMakeLists.txt
@@ -1,70 +1,7 @@
-if (BUILDING_LEATHERMAN)
-    set(${include_var} "${PROJECT_SOURCE_DIR}/vendor/boost-nowide" PARENT_SCOPE)
-    if (WIN32)
-        if (LEATHERMAN_SHARED)
-            set(${lib_var} nowide-shared PARENT_SCOPE)
-        else()
-            set(${lib_var} nowide-static PARENT_SCOPE)
-        endif()
-    endif()
+find_package(Boost 1.54 REQUIRED)
 
-    set(BOOST_NOWIDE_SKIP_TESTS ON CACHE BOOL "Disable tests in Boost.Nowide")
-
-    # Disable installing Boost.Nowide so we don't pollute the
-    # installation. We will handle installing the appropriate header files
-    # to our own vendor include dir.
-    set(BOOST_NOWIDE_SKIP_INSTALL ON CACHE BOOL "Disable installing Boost.Nowide")
-
-    # have to specify a bindir since this isn't actually a subdirectory of us
-    set(srcdir "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/boost-nowide")
-    set(bindir "${CMAKE_CURRENT_BINARY_DIR}/../vendor/boost-nowide")
-    add_subdirectory(${srcdir} ${bindir})
-
-    if (LEATHERMAN_INSTALL)
-        install(DIRECTORY "${srcdir}/boost" DESTINATION "include/leatherman/vendor/boost-nowide")
-
-        if (WIN32)
-            # Have to install as FILES instead of TARGETS because the
-            # target isn't in this CMake file
-            if (LEATHERMAN_SHARED)
-                get_target_property(output_name nowide-shared OUTPUT_NAME)
-                install(FILES "${bindir}/${CMAKE_IMPORT_LIBRARY_PREFIX}${output_name}${CMAKE_IMPORT_LIBRARY_SUFFIX}" DESTINATION "lib")
-                install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_SHARED_LIBRARY_PREFIX}${output_name}${CMAKE_SHARED_LIBRARY_SUFFIX}" DESTINATION "bin")
-            else()
-                get_target_property(output_name nowide-static OUTPUT_NAME)
-                install(FILES "${bindir}/${CMAKE_STATIC_LIBRARY_PREFIX}${output_name}${CMAKE_STATIC_LIBRARY_SUFFIX}" DESTINATION "lib")
-            endif()
-        endif()
-    endif()
-else()
-    set(${include_var} "${LEATHERMAN_PREFIX}/include/leatherman/vendor/boost-nowide")
-
-    if (WIN32)
-        if (LEATHERMAN_SHARED)
-            set(${lib_var} nowide-shared)
-            add_library(nowide-shared SHARED IMPORTED)
-            find_library(NOWIDE_LIB
-                NAMES libnowide
-                PATHS "${LEATHERMAN_PREFIX}/lib"
-                NO_DEFAULT_PATH
-                )
-            set_target_properties(nowide-shared PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-                IMPORTED_LOCATION "${LEATHERMAN_PREFIX}/bin/libnowide.dll"
-                IMPORTED_IMPLIB ${NOWIDE_LIB}
-                )
-        else()
-            set(${lib_var} nowide-static)
-            add_library(nowide-static STATIC IMPORTED)
-            find_library(NOWIDE_LIB
-                NAMES libnowide
-                PATHS "${LEATHERMAN_PREFIX}/lib"
-                NO_DEFAULT_PATH
-                )
-            set_target_properties(nowide-static PROPERTIES
-                IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-                IMPORTED_LOCATION ${NOWIDE_LIB}
-                )
-        endif()
-    endif()
+add_leatherman_includes(${Boost_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}/../vendor/boost-nowide")
+add_leatherman_headers(../vendor/boost-nowide/boost)
+if(WIN32)
+    add_leatherman_library(../vendor/boost-nowide/libs/nowide/src/iostream.cpp)
 endif()


### PR DESCRIPTION
Boost.Nowide used really complicated logic to install the library built from a single source file. It also doesn't work when configuring Leatherman to build shared libraries. Build the source file directly instead.

This can't really be verified without https://github.com/puppetlabs/leatherman/pull/109 and disabling tests via `-DLEATHERMAN_ENABLE_TESTING=OFF` (until LTH-63 is fixed).