### PR TITLE
(LTH-64) Support LIB_SUFFIX for multilib install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(internal)
 if ("${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
     if (NOT CMAKE_BUILD_TYPE)
         message(STATUS "Defaulting to a release build.")
-	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
+        set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
     endif()
 
     set(LEATHERMAN_TOPLEVEL TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,12 @@ if (LEATHERMAN_INSTALL)
         cmake/options.cmake
         cmake/leatherman_config.cmake
     )
-    install(FILES ${CMAKE_FILES} DESTINATION "lib/cmake/leatherman/cmake/")
+    set(INSTALL_LOC "lib${LIB_SUFFIX}/cmake/leatherman")
+    install(FILES ${CMAKE_FILES} DESTINATION "${INSTALL_LOC}/cmake/")
 
     configure_file(LeathermanConfig.cmake.in "${PROJECT_BINARY_DIR}/LeathermanConfig.cmake" @ONLY)
-    install(FILES "${PROJECT_BINARY_DIR}/LeathermanConfig.cmake" DESTINATION "lib/cmake/leatherman")
-    install(EXPORT LeathermanLibraries DESTINATION "lib/cmake/leatherman")
+    install(FILES "${PROJECT_BINARY_DIR}/LeathermanConfig.cmake" DESTINATION ${INSTALL_LOC})
+    install(EXPORT LeathermanLibraries DESTINATION ${INSTALL_LOC})
 
-    install(FILES "scripts/cpplint.py" DESTINATION "lib/cmake/leatherman/scripts/")
+    install(FILES "scripts/cpplint.py" DESTINATION "${INSTALL_LOC}/scripts/")
 endif()

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Leatherman is broken up into a number of focused component
 libraries. Both methods of using Leatherman allow you to control which
 components are built and used.
 
+Library install locations can be controlled using the LIB_SUFFIX
+variable, which results in installing libraries to `lib${LIB_SUFFIX}`.
+
 ### Dependencies
 
 * Boost, at least version 1.54

--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -167,7 +167,7 @@ macro(add_leatherman_dir dir)
             else()
                 set(COMPONENT_STRING "leatherman_component(${id})")
             endif()
-            install(FILES "${dir}/CMakeLists.txt" DESTINATION "lib/cmake/leatherman" RENAME "${id}.cmake")
+            install(FILES "${dir}/CMakeLists.txt" DESTINATION "lib${LIB_SUFFIX}/cmake/leatherman" RENAME "${id}.cmake")
             set(LEATHERMAN_COMPONENTS "${LEATHERMAN_COMPONENTS}\n${COMPONENT_STRING}")
         endif()
 

--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -72,8 +72,8 @@ endmacro()
 macro(leatherman_install)
     install(TARGETS ${ARGV}
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        LIBRARY DESTINATION lib${LIB_SUFFIX}
+        ARCHIVE DESTINATION lib${LIB_SUFFIX})
     foreach(ARG ${ARGV})
         if (TARGET ${ARG})
             set_target_properties(${ARG} PROPERTIES PREFIX "" IMPORT_PREFIX "")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -2,6 +2,7 @@ include(leatherman)
 defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
 defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
 defoption(CURL_STATIC "Use curl's static libraries" OFF)
+set(LIB_SUFFIX "" CACHE STRING "Library install suffix")
 
 # Map our boost option to the for-realsies one
 set(Boost_USE_STATIC_LIBS ${BOOST_STATIC})


### PR DESCRIPTION
Major RPM distributions define the CMake variable LIB_SUFFIX to determine if libraries should be shipped in /usr/lib64 or /usr/lib. Support the LIB_SUFFIX variable.

Depends on https://github.com/puppetlabs/leatherman/pull/109 for LTH-54.