### PR TITLE
(maint) Use GCC 5.2 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,20 +4,19 @@ install:
   - set
   - git submodule update --init --recursive
 
-  - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
+  - choco install -y mingw-w64 -Version 5.2.0 -source https://www.myget.org/F/puppetlabs
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
-  - SET PATH=C:\Ruby21-x64\bin;C:\tools\mingw64\bin;%PATH%
+  - choco install -y pl-boost-x64 -Version 1.58.0.2 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-toolchain-x64 -Version 2015.12.01.1 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-zlib-x64 -Version 1.2.8.1 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
+  - SET PATH=C:\tools\mingw64\bin;C:\tools\pl-build-tools\bin;C:\Ruby21-x64\bin;%PATH%
   - ps: $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
   - ps: $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
 
-  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
-  - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
-
-  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z"
-  - ps: 7z.exe x "curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
-
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DCURL_STATIC=ON -DLEATHERMAN_SHARED="$env:shared" .
+  - ps: cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DBOOST_STATIC=ON -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DLEATHERMAN_SHARED="$env:shared" .
   - ps: mingw32-make install
   - ps: 7z.exe a -t7z leatherman.7z C:\tools\leatherman\
 


### PR DESCRIPTION
Use GCC 5.2 and packages from myget in AppVeyor.