### PR TITLE
DO NOT MERGE Change semantics of file_util::read.

### DIFF
--- a/file_util/inc/leatherman/file_util/file.hpp
+++ b/file_util/inc/leatherman/file_util/file.hpp
@@ -12,6 +12,12 @@
 
 namespace leatherman { namespace file_util {
 
+    class file_error : public std::runtime_error {
+      public:
+        explicit file_error(const char *desc) : runtime_error(desc) {}
+        explicit file_error(const std::string& desc) : runtime_error(desc) {}
+    };
+
     /**
      * Reads each line from the given file.
      * @param path The path to the file to read.
@@ -22,18 +28,13 @@ namespace leatherman { namespace file_util {
 
     /**
      * Reads the entire contents of the given file into a string.
+     * Follows symlinks until a non-symlink path is found.
+     * If the file doesn't exist or can't be opened, a file_error is thrown.
+     * If an I/O error occurs while reading the file, a file_error is thrown.
      * @param path The path of the file to read.
      * @return Returns the file contents as a string.
      */
     std::string read(std::string const& path);
-
-    /**
-     * Reads the entire contents of the given file into a string.
-     * @param path The path of the file to read.
-     * @param contents The returned file contents.
-     * @return Returns true if the contents were read or false if the file is not readable.
-     */
-    bool read(std::string const& path, std::string& contents);
 
     /**
      *@return Returns true if the specified file exists and can

--- a/file_util/tests/directory_utils_test.cc
+++ b/file_util/tests/directory_utils_test.cc
@@ -28,7 +28,7 @@ namespace leatherman { namespace file_util {
         SECTION("can find a file to match a pattern") {
             std::string content = "N/A";
             each_file(directory.get_dir_name(), [&content](std::string const &path) {
-                return read(path, content);
+                content.append(read(path));
             }, "[0-1]");
             REQUIRE(content == "1\n");
         }


### PR DESCRIPTION
Change file_util::read to throw errors rather than return the empty
string when the file doesn't exist, can't be read, or an I/O error
occurred while reading it.

*DO NOT MERGE* I put this up so we can talk about the proposed changes, but it's not yet ready (tests don't compile).