### PR TITLE
(maint) Use a github token encrypted for this repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ env:
 deploy:
   provider: releases
   api_key:
-    secure: Pu4B74hKMM8658PTQg1KCmuHKtOSsrwZ97JYu6LV7WcHMiXe5XkCPgY14cP6dnIVhGGuMfD4RunlnxfxFzlR4I/qqweat4/96prsvu0FqgTjyxcbZ11tiFTkF7mly30YwNhDVCta9R0jHMCcLMmHYMNo8VEHuixh7mB1TDZy6fI=
+    secure: XARXGAo5DNbqu7/EVPlKocdAAdtVqui2yaJiqw8GVXMSsK5lxqkHNfm1UF204y9ONl7DTa1hzBS8VRLupfb2aIjIZWMM68tnWYbyJYNdRUevylPTK01rO9wpR8iVe7xFqQOlDXPrX0UVfKCvf+e1j+IleO5Eyjf1mTLIRR3fuOY=
   file: leatherman.tar.gz
   skip_cleanup: true
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.3.0] - TBD
+## [0.3.1] - 2015-12-16
+
+### Fixed
+
+- The key for publishing builds from travis was incorrectly encrypted.
+
+## [0.3.0] - 2015-12-16
 
 ### Added
 - Option to build dynamic libraries


### PR DESCRIPTION
The previous token was encrypted for puppetlabs/puppet instead of
puppetlabs/leatherman. This one should work for deploys.