### PR TITLE
(maint) Use leatherman_deps instead of target_link_libraries in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.2] - 2015-12-16
+
+### Fixed
+
+- The `windows` library incorrectly used `target_link_libraries` instead of `add_leatherman_deps`
+
 ## [0.3.1] - 2015-12-16
 
 ### Fixed

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -21,8 +21,4 @@ set(WINDOWS_UTIL_SOURCES
 
 add_leatherman_library(${WINDOWS_UTIL_SOURCES})
 add_leatherman_headers(inc/leatherman)
-
-target_link_libraries(leatherman_windows 
-	Wbemuuid.lib
-	userenv.lib
-)
+add_leatherman_deps(Wbemuuid.lib userenv.lib)


### PR DESCRIPTION
target_link_libraries will cause failures when leatherman projects are
pulled in via find_package.