### PR TITLE
(LTH-71) Avoid matching leatherman_ruby.dll

### DIFF
--- a/dynamic_library/src/windows/dynamic_library.cc
+++ b/dynamic_library/src/windows/dynamic_library.cc
@@ -37,18 +37,21 @@ namespace leatherman { namespace dynamic_library {
 
         boost::regex rx(pattern);
         do {
-            if (re_search(boost::nowide::narrow(me32.szModule), rx)) {
+            auto libname = boost::nowide::narrow(me32.szModule);
+            if (re_search(libname, rx)) {
                 // Use GetModuleHandleEx to ensure the reference count is incremented. If the module has been
                 // unloaded since the snapshot was made, this may fail and we should return an empty library.
                 HMODULE hMod;
                 if (GetModuleHandleEx(0, me32.szModule, &hMod)) {
                     library._handle = hMod;
                     library._first_load = false;
-                    LOG_DEBUG("library %1% found from pattern %2%", me32.szModule, pattern);
+                    LOG_DEBUG("library %1% found from pattern %2%", libname, pattern);
                 } else {
-                    LOG_DEBUG("library %1% found from pattern %2%, but unloaded before handle was acquired", me32.szModule, pattern);
+                    LOG_DEBUG("library %1% found from pattern %2%, but unloaded before handle was acquired", libname, pattern);
                 }
                 return library;
+            } else {
+                LOG_TRACE("library %1% didn't match pattern %2%", libname, pattern);
             }
         } while (Module32Next(hModSnap, &me32));
 

--- a/ruby/src/windows/api.cc
+++ b/ruby/src/windows/api.cc
@@ -8,7 +8,12 @@ namespace leatherman { namespace ruby {
 
     lth_lib::dynamic_library api::find_loaded_library()
     {
-        const string libruby_pattern = ".*ruby(\\d)?(\\d)?(\\d)?\\.dll";
+        // Ruby DLL's follow a pattern of
+        //   ruby.dll, libruby.dll, ruby210.dll, libruby210.dll
+        //   msvcrt-ruby193.dll, x64-msvcrt-ruby210.dll, etc
+        // To avoid detecting leatherman_ruby.dll as a Ruby DLL, look for
+        // anything except an underscore.
+        const string libruby_pattern = "^[^_]*ruby(\\d)?(\\d)?(\\d)?\\.dll$";
         return lth_lib::dynamic_library::find_by_pattern(libruby_pattern);
     }
 


### PR DESCRIPTION
When checking whether a Ruby DLL has already been loaded on Windows, we
use a regular expression that also happens to match leatherman_ruby.dll.
Avoid matching it.

A more general solution would be good, but requires more significant
changes.