### PR TITLE
(maint) Document JsonContainer ctor getting empty string

### DIFF
--- a/json_container/README.md
+++ b/json_container/README.md
@@ -28,6 +28,17 @@ The JsonContainer's constructor can throw the following exception:
 
  - data_parse_error - This error is thrown when invalid JSON is passed to the constructor.
 
+Note that you can instantiate JsonContainer by passing a non-empty `std::string`
+representing a JSON object, array, or value. In case you want to pass a JSON
+string, you must include escaped double quotes. For example:
+
+```
+    JsonContainer { "4" };  // a number
+    JsonContainer { "\"fast'n bulbous\"" };  // a string
+    JsonContainer { "null" };  // the null value
+    JsonContainer { "" };  // JsonContainer will throw a data_parse_error!
+```
+
 The following calls to the _get_ method will retrieve values from the JsonContainer.
 
 ```

--- a/json_container/tests/json_container_test.cc
+++ b/json_container/tests/json_container_test.cc
@@ -50,6 +50,10 @@ TEST_CASE("JsonContainer::JsonContainer - passing JSON string", "[data]") {
             }
         }
 
+        SECTION("std::string instance containing an empty JSON string") {
+            json_value = "\"\"";
+        }
+
         SECTION("string") {
             json_value = "\"foo\"";
         }
@@ -75,6 +79,11 @@ TEST_CASE("JsonContainer::JsonContainer - passing JSON string", "[data]") {
         }
 
         REQUIRE_NOTHROW(JsonContainer { json_value });
+    }
+
+    SECTION("it should throw a data_parse_error in case of empty string") {
+        json_value = "";
+        REQUIRE_THROWS_AS(JsonContainer { json_value }, data_parse_error);
     }
 
     SECTION("it should throw a data_parse_error in case of invalid JSON") {


### PR DESCRIPTION
JsonContainer(std::string s) throws a data_parse_error in case `s` is an
empty string. Here we explicit that in the docs and add a couple of unit
tests.