### PR TITLE
(LTH-81) Drop dependencies when using shared libraries

### DIFF
--- a/LeathermanConfig.cmake.in
+++ b/LeathermanConfig.cmake.in
@@ -14,6 +14,8 @@ if (LEATHERMAN_USE_LOCALES AND NOT LEATHERMAN_HAVE_LOCALES)
     message(SEND_ERROR "You requested locale support, but leatherman was built without it")
 endif()
 
+set(LEATHERMAN_SHARED @LEATHERMAN_SHARED@)
+
 debug("Selected components: ${Leatherman_FIND_COMPONENTS}")
 foreach(component ${Leatherman_FIND_COMPONENTS})
     string(TOUPPER "${component}" id_upper)
@@ -36,7 +38,12 @@ foreach(component ${Leatherman_FIND_COMPONENTS})
             # Prepend leatherman libraries, as later libs may depend on earlier libs.
             list(INSERT LEATHERMAN_LIBS 0 ${${lib_var}})
         endif()
-        list(APPEND LEATHERMAN_DEPS ${${deps_var}})
+        if (${LEATHERMAN_SHARED})
+            # Created with shared libraries, ignore dependencies as they're compiled-in.
+            set(${libs_var} ${${lib_var}})
+        else()
+            list(APPEND LEATHERMAN_DEPS ${${deps_var}})
+        endif()
     endif()
 endforeach()
 

--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -93,7 +93,7 @@ macro(add_leatherman_library)
 
     if(LEATHERMAN_SHARED)
         add_library(${libname} SHARED ${LIBRARY_ARGS})
-        target_link_libraries(${libname} ${${deps_var}})
+        target_link_libraries(${libname} PRIVATE ${${deps_var}})
     else()
         add_library(${libname} STATIC ${LIBRARY_ARGS})
     endif()


### PR DESCRIPTION
When Leatherman is built as a set of shared libraries, all required
dependencies are accounted for in the binary files. However the
LEATHERMAN_LIBS and LEATHERMAN_*_LIBS variables still included dependent
libraries, which could be static libraries. When the dependencies are
static libraries, linking using LEATHERMAN_*_LIBS can result in missing
symbols.

Update Leatherman to leave dependencies out of LEATHERMAN_*_LIBS when
built with shared libraries.