### PR TITLE
(doc) Fix instructions to push tags for a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ the `nowide` and `catch` CMake files are both solid examples.
 1. Update [CHANGELOG.md](CHANGELOG.md) with release notes based on
 ``git log `git describe --abbrev=0 --tags`..HEAD``
 1. Update the version in the project declaration of [CMakeLists.txt](CMakeLists.txt)
-1. `git tag -s <version> -m '<version>' && git push <puppetlabs> master`
+1. `git tag -s <version> -m '<version>' && git push <puppetlabs> refs/tags/<version>`
 
 [1]: https://github.com/philsquared/Catch
 [2]: https://github.com/miloyip/rapidjson


### PR DESCRIPTION
The previous instructions to push a release were incorrect, we need to
push the tag itself.