### PR TITLE
(maint) Install pod2man macro alongside other leatherman macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ if (LEATHERMAN_INSTALL)
         cmake/cflags.cmake
         cmake/GetGitRevisionDescription.cmake
         cmake/GetGitRevisionDescription.cmake.in
+        cmake/pod2man.cmake
         cmake/leatherman.cmake
         cmake/options.cmake
         cmake/leatherman_config.cmake


### PR DESCRIPTION
This commit adds the pod2man macro to the list of install leatherman
macros for downstream consumers.