### PR TITLE
(maint) Prep for leatherman 0.3.7 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.7] - 2016-02-10
+
+### Fixed
+
+- Made the pod2man CMake macro available to downstream consumers.
+
 ## [0.3.6] - 2016-02-05
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(LEATHERMAN VERSION 0.3.6)
+project(LEATHERMAN VERSION 0.3.7)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)


### PR DESCRIPTION
We're needing to use the pod2man macro in puppet-code, so I think we need a new release with AJ's fix.