### PR TITLE
(LTH-84) Fix ruby::to_string when not UTF-8

### DIFF
--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.3.6\n"
+"Project-Id-Version: leatherman 0.3.7\n"
 "Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -265,47 +265,47 @@ msgid ""
 msgstr ""
 
 #. info
-#: ruby/src/api.cc:126
+#: ruby/src/api.cc:127
 msgid "ruby loaded from \"{1}\"."
 msgstr ""
 
 #. info
-#: ruby/src/api.cc:128
+#: ruby/src/api.cc:129
 msgid "ruby was already loaded."
 msgstr ""
 
 #. info
-#: ruby/src/api.cc:147
+#: ruby/src/api.cc:176
 msgid "using ruby version {1}"
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:456
+#: ruby/src/api.cc:459
 msgid "preferred ruby library \"{1}\" could not be loaded."
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:466
+#: ruby/src/api.cc:469
 msgid "ruby library \"{1}\" could not be loaded."
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:473
+#: ruby/src/api.cc:476
 msgid "ruby could not be found on the PATH."
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:476
+#: ruby/src/api.cc:479
 msgid "ruby was found at \"{1}\"."
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:485
+#: ruby/src/api.cc:488
 msgid "ruby failed to run: {1}"
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:491
+#: ruby/src/api.cc:494
 msgid ""
 "ruby library \"{1}\" was not found: ensure ruby was built with the --enable-"
 "shared configuration option."

--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -249,6 +249,10 @@ namespace leatherman {  namespace ruby {
         /**
          * See MRI documentation.
          */
+        VALUE (* const rb_str_encode)(VALUE, VALUE, int, VALUE);
+        /**
+         * See MRI documentation.
+         */
         VALUE (* const rb_load)(VALUE, int);
         /**
          * See MRI documentation.
@@ -613,7 +617,7 @@ namespace leatherman {  namespace ruby {
         bool case_equals(VALUE first, VALUE second) const;
 
         /**
-         * Evalutes a string as ruby code.
+         * Evalutes a ASCII string as ruby code.
          * Any exception raised will be propagated as a C++ runtime_error
          * @param code the ruby code to execute
          */

--- a/ruby/tests/api-test.cc
+++ b/ruby/tests/api-test.cc
@@ -163,3 +163,16 @@ TEST_CASE("api::lookup", "[ruby-api]") {
         REQUIRE(ruby.to_string(ruby.lookup({ "Foo", "Bar" })) == "Foo::Bar");
     }
 }
+
+TEST_CASE("api::to_string", "[ruby-api]") {
+    auto& ruby = api::instance();
+    ruby.initialize();
+    REQUIRE(ruby.initialized());
+
+    SECTION("can normalize encodings") {
+        string john {"J\xc3\xb6hn"};
+        auto obj = ruby.utf8_value(john);
+        auto encoded = ruby.rb_funcall(obj, ruby.rb_intern("encode"), 1, ruby.utf8_value("Windows-1252"));
+        REQUIRE(ruby.to_string(encoded) == john);
+    }
+}


### PR DESCRIPTION
When calling ruby::to_string on a non-UTF-8 encoding, the binary
representation returned will be interpreted incorrectly by the caller.