### PR TITLE
(maint) Fix project include lookup

### DIFF
--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -81,7 +81,7 @@ endmacro()
 #
 # This macro cannot be invoked multiple times
 macro(add_leatherman_library)
-    include_directories(${${include_var}})
+    include_directories(BEFORE ${${include_var}})
 
     set(LIBRARY_ARGS ${ARGV})
     list(FIND LIBRARY_ARGS EXPORTS EXPORTS_IDX)


### PR DESCRIPTION
Without this change, building Leatherman after it's already been installed
to CMAKE_INSTALL_PREFIX (or if an install happens to exist in
CMAKE_PREFIX_PATH) will pickup the old installed headers before the
Leatherman headers in the project. Fix `include_directories` to add the
project includes first.