### PR TITLE
Support projects that don't use gettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ use `{N}` in as the substitution token for your strings.
 
 Translation isn't supported on AIX or Solaris, as GCC on those platforms
 doesn't support `std::locale`. In fact std::locale is buggy, so avoid
-using `get_locale` as well.
+using `get_locale` as well. The CMake option `LEATHERMAN_USE_LOCALES`
+can be used to enable or disable building with Boost.Locale and using
+`std::locale`.
 
 To use `leatherman::locale::translate` or `leatherman::locale::format`
 in your project, add an include to the top of your cpp file:

--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -227,6 +227,11 @@ endmacro()
 #
 # Compile gettext .po files into .mo files and configure installing to inst
 # Creates a custom target `translations`.
+#
+# Does nothing if msgfmt (part of gettext) isn't found. Sets GETTEXT_ENABLED
+# to ON if we can compile .mo files, otherwise sets to OFF. This variable can
+# be used to disable functionality (such as testing) that requires gettext
+# translation files.
 macro(gettext_compile dir inst)
     # Don't even try to find gettext on AIX or Solaris, we don't want it.
     if (LEATHERMAN_USE_LOCALES)
@@ -250,8 +255,10 @@ macro(gettext_compile dir inst)
             add_dependencies(translations ${lang}-${PROJECT_NAME})
             install(FILES ${mo} DESTINATION "${inst}/${lang}/LC_MESSAGES")
         endforeach()
+        set(GETTEXT_ENABLED ON)
     else()
         message(STATUS "Could not find gettext executables, skipping gettext_compile.")
+        set(GETTEXT_ENABLED OFF)
     endif()
 endmacro()
 

--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -166,7 +166,7 @@ endmacro()
 # Creates a custom target `translation`.
 macro(gettext_templates dir)
     # Don't even try to find gettext on AIX or Solaris, we don't want it.
-    if (LEATHERMAN_ENABLE_LOCALE)
+    if (LEATHERMAN_USE_LOCALES)
         find_program(XGETTEXT_EXE xgettext)
     endif()
 
@@ -229,7 +229,7 @@ endmacro()
 # Creates a custom target `translations`.
 macro(gettext_compile dir inst)
     # Don't even try to find gettext on AIX or Solaris, we don't want it.
-    if (LEATHERMAN_ENABLE_LOCALE)
+    if (LEATHERMAN_USE_LOCALES)
         find_program(MSGFMT_EXE msgfmt)
     endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -11,7 +11,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "AIX" OR CMAKE_SYSTEM_NAME MATCHES "SunOS")
 else()
     set(USE_BOOST_LOCALE TRUE)
 endif()
-defoption(LEATHERMAN_ENABLE_LOCALE "Use locales for internationalization" ${USE_BOOST_LOCALE})
+defoption(LEATHERMAN_USE_LOCALES "Use locales for internationalization" ${USE_BOOST_LOCALE})
 
 # Map our boost option to the for-realsies one
 set(Boost_USE_STATIC_LIBS ${BOOST_STATIC})

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -11,7 +11,13 @@ add_leatherman_headers(inc/leatherman)
 
 if (LEATHERMAN_USE_LOCALES)
     add_leatherman_library(src/locale.cc)
-    add_leatherman_test(tests/locale.cc)
+    if (GETTEXT_ENABLED)
+        # This test relies on translation .mo files being generated.
+        # Projects that don't support localization yet still need
+        # tests to pass, so only enable these tests if gettext is
+        # available.
+        add_leatherman_test(tests/locale.cc)
+    endif()
 else()
     add_leatherman_library(disabled/locale.cc)
 endif()

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (LEATHERMAN_ENABLE_LOCALE)
+if (LEATHERMAN_USE_LOCALES)
     find_package(Boost 1.54 REQUIRED COMPONENTS locale system)
 else()
     find_package(Boost 1.54 REQUIRED regex)
@@ -9,7 +9,7 @@ add_leatherman_deps(${Boost_LIBRARIES})
 
 add_leatherman_headers(inc/leatherman)
 
-if (LEATHERMAN_ENABLE_LOCALE)
+if (LEATHERMAN_USE_LOCALES)
     add_leatherman_library(src/locale.cc)
     add_leatherman_test(tests/locale.cc)
 else()

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.3.7\n"
+"Project-Id-Version: leatherman 0.4.0\n"
 "Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -77,7 +77,7 @@ namespace leatherman { namespace logging {
         boost::shared_ptr<sink_t> sink(new sink_t(&dst));
         core->add_sink(sink);
 
-#if (!defined(__sun) && !defined(_AIX)) || !defined(__GNUC__)
+#ifdef LEATHERMAN_USE_LOCALES
         // Imbue the logging sink with the requested locale.
         // Locale in GCC is busted on Solaris, so skip it.
         // TODO: Imbue may not be useful, as setup_logging can be called multiple times


### PR DESCRIPTION
Disables localization tests when gettext isn't available.

Also does some minor cleanup.