### PR TITLE
(LTH-87) Fix build on OS X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.1] - 2016-03-02
+
+### Fixed
+- Install `generate_translations.cmake` for internationalization
+- Fix builds on Mac OS X against static boost
+
 ## [0.4.0] - 2016-02-23
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.4.0)
+project(leatherman VERSION 0.4.1)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -7,6 +7,13 @@ endif()
 add_leatherman_includes(${Boost_INCLUDE_DIRS})
 add_leatherman_deps(${Boost_LIBRARIES})
 
+if (LEATHERMAN_USE_LOCALES AND BOOST_STATIC AND APPLE)
+    # Boost.Locale relies on libiconv; if not using shared boost libraries
+    # we need to include the dependency ourselves. So far this is only a
+    # problem on Mac OS X.
+    add_leatherman_deps(iconv)
+endif()
+
 add_leatherman_headers(inc/leatherman)
 
 if (LEATHERMAN_USE_LOCALES)

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.4.0\n"
+"Project-Id-Version: leatherman 0.4.1\n"
 "Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Building with static boost libraries on Mac OS X fails because
Boost.Locale requires iconv. Add iconv as a dependency on Mac OS X when
building against static boost.