### PR TITLE
(LTH-90) Execution with new process group on Windows

### DIFF
--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -57,6 +57,10 @@ namespace leatherman { namespace execution {
          */
         preserve_arguments = (1 << 7),
         /**
+         * On Windows, create a new process group for the child process, but not a Job Object.
+         */
+        create_new_process_group = (1 << 8),
+        /**
          * A combination of all throw options.
          */
         throw_on_failure = throw_on_nonzero_exit | throw_on_signal,

--- a/execution/tests/windows/execution.cc
+++ b/execution/tests/windows/execution.cc
@@ -123,6 +123,13 @@ SCENARIO("executing commands with execution::execute") {
             REQUIRE(exec.error == "");
             REQUIRE(exec.exit_code == 0);
         }
+        WHEN("the create new process group option is used") {
+            auto exec = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file3.txt") }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null, execution_options::create_new_process_group });
+            REQUIRE(exec.success);
+            REQUIRE(exec.output == "file3");
+            REQUIRE(exec.error == "");
+            REQUIRE(exec.exit_code == 0);
+        }
         WHEN("expecting input") {
             auto exec = execute("cmd.exe", { "/c", CMAKE_BIN_DIRECTORY "/lth_cat.exe" }, "hello");
             REQUIRE(exec.success);
@@ -212,6 +219,15 @@ SCENARIO("executing commands with execution::execute") {
     GIVEN("a command that fails") {
         WHEN("default options are used") {
             auto exec = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" });
+            THEN("no output is returned") {
+                REQUIRE_FALSE(exec.success);
+                REQUIRE(exec.output == "");
+                REQUIRE(exec.error == "");
+                REQUIRE(exec.exit_code > 0);
+            }
+        }
+        WHEN("the create new process group option is used") {
+            auto exec = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null, execution_options::create_new_process_group });
             THEN("no output is returned") {
                 REQUIRE_FALSE(exec.success);
                 REQUIRE(exec.output == "");


### PR DESCRIPTION
Adding a new execution_option to the Execution lib to create child
processes in Windows with a new process group and avoid createing
or terminating a related Job Object.