### PR TITLE
(LTH-74) Switch BOOST_STATIC to ON by default

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - ps: 7z.exe x "curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
 
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DCURL_STATIC=ON -DLEATHERMAN_SHARED="$env:shared" .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DCURL_STATIC=ON -DLEATHERMAN_SHARED="$env:shared" .
   - ps: mingw32-make install
   - ps: 7z.exe a -t7z leatherman.7z C:\tools\leatherman\
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,6 @@
 include(leatherman)
 defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
-defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
+defoption(BOOST_STATIC "Use Boost's static libraries" ON)
 defoption(CURL_STATIC "Use curl's static libraries" OFF)
 set(LIB_SUFFIX "" CACHE STRING "Library install suffix")
 


### PR DESCRIPTION
Our packaging builds with static Boost libraries. Switch the Leatherman
default to do the same so developer builds are more consistent with
packaging builds.