### PR TITLE
(LTH-91) Switch to using fixed-size ints

### DIFF
--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.4.1\n"
+"Project-Id-Version: leatherman 0.4.2\n"
 "Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -131,7 +131,7 @@ msgstr ""
 #: execution/src/posix/execution.cc:269
 #: execution/src/windows/execution.cc:277
 #: execution/src/windows/execution.cc:352
-#: execution/src/windows/execution.cc:633
+#: execution/src/windows/execution.cc:645
 msgid "command timed out after {1} seconds."
 msgstr ""
 
@@ -199,47 +199,47 @@ msgid "child environment {1}={2}"
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:547
+#: execution/src/windows/execution.cc:558
 msgid "failed to create process: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:568
+#: execution/src/windows/execution.cc:580
 msgid "failed to create job object: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:571
+#: execution/src/windows/execution.cc:583
 msgid "failed to associate process with job object: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:582
+#: execution/src/windows/execution.cc:594
 msgid "failed to terminate process: {1}."
 msgstr ""
 
 #. warning
-#: execution/src/windows/execution.cc:585
+#: execution/src/windows/execution.cc:597
 msgid "could not terminate process {1} because a job object could not be used."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:595
+#: execution/src/windows/execution.cc:607
 msgid "failed to create waitable timer: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:604
+#: execution/src/windows/execution.cc:616
 msgid "failed to set waitable timer: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:635
+#: execution/src/windows/execution.cc:647
 msgid "failed to wait for child process to terminate: {1}."
 msgstr ""
 
 #. debug
-#: execution/src/windows/execution.cc:645
+#: execution/src/windows/execution.cc:657
 msgid "process exited with exit code {1}."
 msgstr ""
 
@@ -280,32 +280,32 @@ msgid "using ruby version {1}"
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:459
+#: ruby/src/api.cc:461
 msgid "preferred ruby library \"{1}\" could not be loaded."
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:469
+#: ruby/src/api.cc:471
 msgid "ruby library \"{1}\" could not be loaded."
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:476
+#: ruby/src/api.cc:478
 msgid "ruby could not be found on the PATH."
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:479
+#: ruby/src/api.cc:481
 msgid "ruby was found at \"{1}\"."
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:488
+#: ruby/src/api.cc:490
 msgid "ruby failed to run: {1}"
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:494
+#: ruby/src/api.cc:496
 msgid ""
 "ruby library \"{1}\" was not found: ensure ruby was built with the --enable-"
 "shared configuration option."

--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -44,6 +44,11 @@ namespace leatherman {  namespace ruby {
     /**
      * See MRI documentation.
      */
+    using LONG_LONG = int64_t;
+    using ULONG_LONG = uint64_t;
+    /**
+     * See MRI documentation.
+     */
     typedef uintptr_t ID;
 
     /**
@@ -209,11 +214,11 @@ namespace leatherman {  namespace ruby {
         /**
          * See MRI documentation.
          */
-        VALUE (* const rb_num2ulong)(VALUE);
+        ULONG_LONG (* const rb_num2ull)(VALUE);
         /**
          * See MRI documentation.
          */
-        SIGNED_VALUE (* const rb_num2long)(VALUE);
+        LONG_LONG (* const rb_num2ll)(VALUE);
         /**
          * See MRI documentation.
          */

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -48,8 +48,8 @@ namespace leatherman { namespace ruby {
         LOAD_SYMBOL(rb_proc_new),
         LOAD_SYMBOL(rb_block_call),
         LOAD_SYMBOL(rb_funcall_passing_block),
-        LOAD_SYMBOL(rb_num2ulong),
-        LOAD_SYMBOL(rb_num2long),
+        LOAD_SYMBOL(rb_num2ull),
+        LOAD_SYMBOL(rb_num2ll),
         LOAD_SYMBOL(rb_num2dbl),
         LOAD_SYMBOL(rb_string_value_ptr),
         LOAD_SYMBOL(rb_rescue2),
@@ -238,7 +238,7 @@ namespace leatherman { namespace ruby {
     {
         v = rb_funcall(v, rb_intern("to_s"), 0);
         v = rb_str_encode(v, utf8_value("UTF-8"), 0, _nil);
-        size_t size = static_cast<size_t>(rb_num2ulong(rb_funcall(v, rb_intern("bytesize"), 0)));
+        auto size = rb_num2ull(rb_funcall(v, rb_intern("bytesize"), 0));
         return string(rb_string_value_ptr(&v), size);
     }
 
@@ -402,7 +402,9 @@ namespace leatherman { namespace ruby {
 
     long api::array_len(VALUE array) const
     {
-        return rb_num2ulong(rb_funcall(array, rb_intern("size"), 0));
+        // This is used for rb_ary_entry, which only accepts a 'long'. So we only expect to
+        // encounter long values here.
+        return static_cast<long>(rb_num2ull(rb_funcall(array, rb_intern("size"), 0)));
     }
 
     VALUE api::lookup(std::initializer_list<std::string> const& names) const


### PR DESCRIPTION
Longs have different size on Windows and Linux. Prefer to get long longs,
which are always 64-bits.