### PR TITLE
(maint) Fix 32-bit compilation

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -73,6 +73,17 @@ namespace leatherman {  namespace ruby {
     };
 
     /**
+     * Exception thrown when Ruby to C type conversions fail.
+     */
+    struct invalid_conversion : std::runtime_error {
+        /**
+         * Constructs an invalid_conversion exception.
+         * @param message The exception message.
+         */
+        explicit invalid_conversion(std::string const& message);
+    };
+
+    /**
      * Contains utility functions and the pointers to the Ruby API.
      */
     struct api
@@ -103,7 +114,7 @@ namespace leatherman {  namespace ruby {
 
         /**
          * Gets the Ruby API instance.
-         * Throws a runtime_error if the API instance can't be created.
+         * Throws a library_not_loaded_exception if the API instance can't be created.
          * @return Returns the Ruby API instance.
          */
         static api& instance();
@@ -429,6 +440,14 @@ namespace leatherman {  namespace ruby {
         std::vector<std::string> get_load_path() const;
 
         /**
+         * Converts a Ruby number into a size_t integer, with checking for overflow.
+         * Throws an invalid_conversion if overflow is detected.
+         * @param v The Ruby value to convert.
+         * @return Returns the Ruby value as a size_t integer.
+         */
+        size_t num2size_t(VALUE v) const;
+
+        /**
          * Converts a Ruby value into a C++ string.
          * @param v The Ruby value to convert.
          * @return Returns the Ruby value as a string.
@@ -593,6 +612,7 @@ namespace leatherman {  namespace ruby {
 
         /**
          * Get the length of a ruby array.
+         * Throws an invalid_conversion if teh array length can not be represented by a long.
          * @return Returns the length of the array.
          */
         long array_len(VALUE array) const;

--- a/ruby/tests/api-test.cc
+++ b/ruby/tests/api-test.cc
@@ -176,3 +176,30 @@ TEST_CASE("api::to_string", "[ruby-api]") {
         REQUIRE(ruby.to_string(encoded) == john);
     }
 }
+
+TEST_CASE("api::num2size_t", "[ruby-api]") {
+    auto& ruby = api::instance();
+    ruby.initialize();
+    REQUIRE(ruby.initialized());
+
+    SECTION("can convert Ruby number to size_t") {
+        auto fixednum = ruby.eval("1");
+        auto num = ruby.num2size_t(fixednum);
+        REQUIRE(1u == num);
+    }
+
+    SECTION("can convert large Ruby number to size_t") {
+        auto expected = numeric_limits<size_t>::max();
+        auto largenum = ruby.eval(to_string(expected));
+        auto num = ruby.num2size_t(largenum);
+        REQUIRE(expected == num);
+    }
+
+#if 0
+    // Can't use this test yet, because Ruby SIGSEGVs on calling rb_num2ull.
+    SECTION("throws exception on Ruby numbers exceeding size_t") {
+        auto largenum = ruby.eval("184467440737095516150");
+        REQUIRE_THROWS_AS(ruby.num2size_t(largenum), runtime_error);
+    }
+#endif
+}


### PR DESCRIPTION
A change to using 64-bit integers in the Ruby API assumed size_t would
always be 64-bit. That breaks 32-bit compilation. Restore explicitly
casting to size_t.

Getting a size and expecting it to match size_t is also a common
pattern. Add a helper that does bounds-checking for that cast.