### PR TITLE
(maint) Add is_bignum to Ruby API

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -585,6 +585,13 @@ namespace leatherman {  namespace ruby {
          */
         bool is_fixednum(VALUE value) const;
 
+         /**
+         * Determines if the given value is a big number (Bignum).
+         * @param value The value to check.
+         * @return Returns true if the given value is a fixed number (Fixnum) or false if it is not.
+         */
+        bool is_bignum(VALUE value) const;
+
         /**
          * Determines if the given value is a float.
          * @param value The value to check.

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -393,6 +393,11 @@ namespace leatherman { namespace ruby {
         return is_a(value, *rb_cFixnum);
     }
 
+    bool api::is_bignum(VALUE value) const
+    {
+        return is_a(value, *rb_cBignum);
+    }
+
     bool api::is_float(VALUE value) const
     {
         return is_a(value, *rb_cFloat);

--- a/ruby/tests/api-test.cc
+++ b/ruby/tests/api-test.cc
@@ -1,5 +1,6 @@
 #include <catch.hpp>
 #include <leatherman/ruby/api.hpp>
+#include <limits>
 
 using namespace std;
 using namespace leatherman::ruby;
@@ -49,6 +50,10 @@ TEST_CASE("api::is_*", "[ruby-api]") {
 
         REQUIRE(ruby.is_fixednum(ruby.eval("2")));
         REQUIRE_FALSE(ruby.is_fixednum(ruby.eval("1.5")));
+
+        REQUIRE(ruby.is_bignum(ruby.eval(to_string(numeric_limits<int64_t>::max()))));
+        REQUIRE_FALSE(ruby.is_bignum(ruby.eval("2")));
+        REQUIRE_FALSE(ruby.is_bignum(ruby.eval("1.5")));
     }
 
     SECTION("can correctly identify hashes") {


### PR DESCRIPTION
Prior to this commit, the Ruby API in leatherman did not have a
method to identify a bignum. Add this method so that we can
identify bignums in addition to fixednums and doubles in facter.