### PR TITLE
(LTH-93) Support building on Nano Server

### DIFF
--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -66,6 +66,13 @@ if (COVERALLS)
 endif()
 
 if (WIN32)
+    # Update standard link libraries to explicitly exclude kernel32. It isn't necessary, and when compiling with
+    # MinGW makes the executable unusable on Microsoft Nano Server due to including __C_specific_handler.
+    SET(CMAKE_C_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
+        CACHE STRING "Standard C link libraries." FORCE)
+    SET(CMAKE_CXX_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
+        CACHE STRING "Standard C++ link libraries." FORCE)
+
     # We currently support Windows Server 2003, which requires using deprecated APIs.
     # See http://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx for version strings.
     # When Server 2003 support is discontinued, the networking facts implementation can be cleaned up, and

--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -73,16 +73,14 @@ if (WIN32)
     SET(CMAKE_CXX_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
         CACHE STRING "Standard C++ link libraries." FORCE)
 
-    # We currently support Windows Server 2003, which requires using deprecated APIs.
-    # See http://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx for version strings.
-    # When Server 2003 support is discontinued, the networking facts implementation can be cleaned up, and
-    # we can statically link symbols that are currently being looked up at runtime.
-    add_definitions(-DWINVER=0x0600 -D_WIN32_WINNT=0x0600)
+    # We currently support Windows Vista and later APIs, see
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx for version strings.
+    list(APPEND LEATHERMAN_DEFINITIONS -DWINVER=0x0600 -D_WIN32_WINNT=0x0600)
 
     # The GetUserNameEx function requires the application have a defined security level.
     # We define security sufficient to get the current user's info.
     # Also force use of UNICODE APIs, following the pattern outlined at http://utf8everywhere.org/.
-    set(LEATHERMAN_DEFINITIONS -DUNICODE -D_UNICODE -DSECURITY_WIN32)
+    list(APPEND LEATHERMAN_DEFINITIONS -DUNICODE -D_UNICODE -DSECURITY_WIN32)
 endif()
 
 # Enforce UTF-8 in Leatherman.Logging; disable deprecated names in Boost.System to avoid warnings on Windows.

--- a/curl/tests/CMakeLists.txt
+++ b/curl/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(CURL REQUIRED)
 
-include_directories(${CURL_INCLUDE_DIRS})
+include_directories(BEFORE ${CURL_INCLUDE_DIRS})
 
 if (CURL_STATIC)
     set(CURL_LINK STATIC)

--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -28,7 +28,7 @@ add_leatherman_test(tests/log_capture.cc ${PLATFORM_TESTS})
 
 if (BUILDING_LEATHERMAN)
     # Dumb implementation of cat.exe for testing stdin/stdout/stderr handling.
-    include_directories(${LEATHERMAN_NOWIDE_INCLUDE})
+    include_directories(BEFORE ${LEATHERMAN_NOWIDE_INCLUDE})
     add_executable(lth_cat tests/lth_cat.cc)
     target_link_libraries(lth_cat ${LEATHERMAN_NOWIDE_LIBS})
     if (COVERALLS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${LEATHERMAN_CATCH_INCLUDE} ${LEATHERMAN_INCLUDE_DIRS})
+include_directories(BEFORE ${LEATHERMAN_CATCH_INCLUDE} ${LEATHERMAN_INCLUDE_DIRS})
 add_executable(leatherman_test main.cc ${LEATHERMAN_TEST_SRCS})
 
 if (LEATHERMAN_SHARED)

--- a/windows/src/wmi.cc
+++ b/windows/src/wmi.cc
@@ -24,7 +24,11 @@ namespace leatherman { namespace windows {
     static string format_hresult(std::string s, HRESULT hres)
     {
         // LOCALE: format a pointer as hex for printing an error message.
+#ifdef LEATHERMAN_I18N
         return lth_locale::format("{1} (0x{2,num=hex})", s, hres);
+#else
+        return lth_locale::format("%1% (0x%2$#x)", s, hres);
+#endif
     }
 
     // GUID taken from a Windows installation and unaccepted change to MinGW-w64. The MinGW-w64 library


### PR DESCRIPTION
CMake adds `-lkernel32` to the list of link libraries by default. However,
doing so with MinGW-w64 introduces an unsatisfied dependency on Nano
Server, causing any executable to fail to run. Explicitly set default link
libraries for all C++ projects to avoid linking kernel32.

Also
- Fix output on WMI error
- Ensure explicit dependencies are first