### PR TITLE
(maint) Fix compilation on Mac OS X using Clang

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -13,6 +13,9 @@
 #include <initializer_list>
 
 #include <leatherman/dynamic_library/dynamic_library.hpp>
+#ifndef _WIN32
+    #include <sys/types.h>
+#endif
 
 namespace leatherman {  namespace ruby {
 


### PR DESCRIPTION
`pid_t` was added to a header without the corresponding include file
`sys/types.h`. On Linux this was fine, but on Mac OS X it causes
compilation errors. Add the include statement.