### PR TITLE
(LTH-94) Add Boost.Regex to all libs using Leatherman.Logging, prepare 0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.2] - 2016-04-20
+
+### Fixed
+- Runtime shared library load errors on AIX.
+
 ## [0.6.1] - 2016-04-19
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.6.1)
+project(leatherman VERSION 0.6.2)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)

--- a/curl/CMakeLists.txt
+++ b/curl/CMakeLists.txt
@@ -1,3 +1,8 @@
+find_package(Boost 1.54 REQUIRED COMPONENTS regex)
+
+add_leatherman_deps("${Boost_LIBRARIES}")
+add_leatherman_includes("${Boost_INCLUDE_DIRS}")
+
 if (BUILDING_LEATHERMAN)
     # Create a mock curl library; it needs to be separate to allow for dllimport in the client source
     # Do it first to avoid symbol_exports defined later.

--- a/dynamic_library/CMakeLists.txt
+++ b/dynamic_library/CMakeLists.txt
@@ -1,3 +1,8 @@
+find_package(Boost 1.54 REQUIRED COMPONENTS regex)
+
+add_leatherman_deps("${Boost_LIBRARIES}")
+add_leatherman_includes("${Boost_INCLUDE_DIRS}")
+
 leatherman_dependency(logging)
 leatherman_dependency(util)
 if(WIN32)

--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -1,3 +1,8 @@
+find_package(Boost 1.54 REQUIRED COMPONENTS regex filesystem system)
+
+add_leatherman_deps("${Boost_LIBRARIES}")
+add_leatherman_includes("${Boost_INCLUDE_DIRS}")
+
 leatherman_dependency(util)
 leatherman_dependency(nowide)
 leatherman_dependency(logging)

--- a/file_util/CMakeLists.txt
+++ b/file_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS filesystem system)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex filesystem system)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS filesystem system)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex filesystem system)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")


### PR DESCRIPTION
On AIX, symbols aren't being resolved from other libraries from dynamic
libraries. In particular, the Boost.Log header files included in
Leatherman.Logging's header uses Boost.Regex, requiring any projects
relying on Leatherman.Logging to link Boost.Regex. Add that dependency.

Leatherman.Execution also had dependencies on Boost.Filesystem that were
being fulfilled from other libraries. Ensure those are called out
explicitly as well, again to resolve runtime failures on AIX.