### PR TITLE
(maint) Use Boost.Log sink's flush property

### DIFF
--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -258,7 +258,7 @@ msgstr ""
 msgid "{1} has not been set"
 msgstr ""
 
-#: logging/src/logging.cc:189
+#: logging/src/logging.cc:195
 msgid ""
 "invalid log level '%1%': expected none, trace, debug, info, warn, error, or "
 "fatal."

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -35,11 +35,12 @@ namespace leatherman { namespace logging {
 
     namespace lth_locale = leatherman::locale;
 
-    class color_writer : public sinks::basic_sink_backend<sinks::synchronized_feeding>
+    class color_writer : public sinks::basic_sink_backend<sinks::combine_requirements<sinks::synchronized_feeding, sinks::flushing>::type>
     {
      public:
         color_writer(ostream *dst);
         void consume(boost::log::record_view const& rec);
+        void flush();
      private:
         ostream &_dst;
     };
@@ -64,7 +65,12 @@ namespace leatherman { namespace logging {
         colorize(_dst, *level);
         _dst << *message;
         colorize(_dst);
-        _dst << endl;
+        _dst << "\n";
+    }
+
+    void color_writer::flush()
+    {
+        _dst.flush();
     }
 
     void setup_logging(ostream &dst, string locale, string domain)


### PR DESCRIPTION
Use the flushing requirement to let Boost.Log control when the sink is
flushed, rather than flushing on every message. This can potentially speed
up writing, as flushes are expensive. It may result in missing some
messages in the case of a crash however.