### PR TITLE
(maint) Make prefixing project includes the default

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -2,6 +2,7 @@ include(leatherman)
 defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
 defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
 defoption(CURL_STATIC "Use curl's static libraries" OFF)
+set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON CACHE BOOL "Prepend project includes before system includes")
 set(LIB_SUFFIX "" CACHE STRING "Library install suffix")
 
 # Solaris and AIX have poor support for std::locale and boost::locale


### PR DESCRIPTION
Ensures project include files are always preferred over system include
files, avoiding the problem of picking up headers from an installed copy
of Leatherman while building.