### PR TITLE
(maint) Disable fragile test

### DIFF
--- a/logging/tests/logging_on_message.cc
+++ b/logging/tests/logging_on_message.cc
@@ -47,7 +47,7 @@ TEST_CASE("logging with on_message") {
         REQUIRE(level == log_level::fatal);
         REQUIRE(message == "fatal message");
     }
-#if defined(__clang__) || __GNUC__ >= 5
+#if 0
     SECTION("a unicode characters to log") {
         const wstring symbols[] = {L"\u2122", L"\u2744", L"\u039b"};
         for (auto const& s : symbols) {


### PR DESCRIPTION
This seems to fail in just about every CI environment, but has been
difficult to reproduce. Skip the test for now.