### PR TITLE
Changes COM apartment model for Nano Server

### DIFF
--- a/windows/src/wmi.cc
+++ b/windows/src/wmi.cc
@@ -38,7 +38,7 @@ namespace leatherman { namespace windows {
     wmi::wmi()
     {
         LOG_DEBUG("initializing WMI");
-        auto hres = CoInitializeEx(0, COINIT_APARTMENTTHREADED);
+        auto hres = CoInitializeEx(0, COINIT_MULTITHREADED);
         if (FAILED(hres)) {
             if (hres == RPC_E_CHANGED_MODE) {
                 LOG_DEBUG("using prior COM concurrency model");


### PR DESCRIPTION
Windows Nano Server does not support COINIT_APARTMENTTHREADED.
Switching to COINIT_MULTITHREADED fixes the issue while retaining compatibility
with any supported Windows version.