### PR TITLE
(LTH-97) Allow applications to disable locale support

### DIFF
--- a/locale/locales/leatherman_test.pot
+++ b/locale/locales/leatherman_test.pot
@@ -17,6 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: locale/locales/../tests/locale.cc:13
+#: locale/locales/../tests/locale.cc:12
 msgid "requesting {1,number}."
 msgstr ""

--- a/locale/src/locale.cc
+++ b/locale/src/locale.cc
@@ -51,7 +51,11 @@ namespace leatherman { namespace locale {
 
     string translate(string const& s, string const& domain)
     {
-        return boost::locale::translate(s).str(get_locale("", domain));
+        try {
+            return boost::locale::translate(s).str(get_locale("", domain));
+        } catch (exception const&) {
+            return s;
+        }
     }
 
 }}  // namespace leatherman::locale

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -258,7 +258,7 @@ msgstr ""
 msgid "{1} has not been set"
 msgstr ""
 
-#: logging/src/logging.cc:192
+#: logging/src/logging.cc:195
 msgid ""
 "invalid log level '%1%': expected none, trace, debug, info, warn, error, or "
 "fatal."

--- a/logging/inc/leatherman/logging/logging.hpp
+++ b/logging/inc/leatherman/logging/logging.hpp
@@ -151,8 +151,9 @@ namespace leatherman { namespace logging {
      * @param dst Destination stream for logging output.
      * @param locale The locale identifier to use for logging.
      * @param domain The catalog domain to use for i18n via gettext.
+     * @param use_locale Whether to use locales in logging setup. If locales are disabled this parameter is ignored.
      */
-    void setup_logging(std::ostream &dst, std::string locale = "", std::string domain = PROJECT_NAME);
+    void setup_logging(std::ostream &dst, std::string locale = "", std::string domain = PROJECT_NAME, bool use_locale = true);
 
     /**
      * Sets the current log level.

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -67,7 +67,7 @@ namespace leatherman { namespace logging {
         _dst << endl;
     }
 
-    void setup_logging(ostream &dst, string locale, string domain)
+    void setup_logging(ostream &dst, string locale, string domain, bool use_locale)
     {
         // Remove existing sinks before adding a new one
         auto core = boost::log::core::get();
@@ -77,6 +77,7 @@ namespace leatherman { namespace logging {
         boost::shared_ptr<sink_t> sink(new sink_t(&dst));
         core->add_sink(sink);
 
+
 #ifdef LEATHERMAN_USE_LOCALES
         // Imbue the logging sink with the requested locale.
         // Locale in GCC is busted on Solaris, so skip it.
@@ -85,7 +86,9 @@ namespace leatherman { namespace logging {
         // Note that this creates a locale that's not usable for testing, as it
         // only includes paths for install locations. This is intentional, to avoid leaving
         // searching paths that have unknown permissions.
-        dst.imbue(lth_locale::get_locale(locale, domain, {}));
+        if (use_locale) {
+            dst.imbue(lth_locale::get_locale(locale, domain, {}));
+        }
 #endif
 
         boost::log::add_common_attributes();


### PR DESCRIPTION
Previously, if the logging library was built with locale support it
would always be used. This adds a new parameter to the setup_logging
function to allow applications to disable locale support if they
desire.