### PR TITLE
(maint) Fix compilation with LEATHERMAN_USE_LOCALES=OFF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ env:
     - TRAVIS_TARGET=RELEASE
     - TRAVIS_TARGET=DEBUG
     - TRAVIS_TARGET=SHARED_RELEASE
+    - TRAVIS_TARGET=LOCALE_DISABLED
 deploy:
   provider: releases
   api_key:

--- a/locale/disabled/locale.cc
+++ b/locale/disabled/locale.cc
@@ -2,18 +2,20 @@
 
 namespace leatherman { namespace locale {
 
-    const std::locale get_locale(std::string const& id, std::string const& domain, std::vector<std::string> const& paths)
+    using namespace std;
+
+    const std::locale get_locale(string const& id, string const& domain, vector<string> const& paths)
     {
         // std::locale is not supported on these platforms
-        throw std::runtime_error("leatherman::locale::get_locale is not supported on this platform");
+        throw runtime_error("leatherman::locale::get_locale is not supported on this platform");
     }
 
-    void clear_domain(std::string const& domain)
+    void clear_domain(string const& domain)
     {
-        throw std::runtime_error("leatherman::locale::clear_domain is not supported on this platform");
+        throw runtime_error("leatherman::locale::clear_domain is not supported on this platform");
     }
 
-    std::string translate(std::string const& msg, std::string const& domain)
+    string translate(string const& msg, string const& domain)
     {
         return msg;
     }

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -14,6 +14,7 @@ function travis_make()
     # Generate build files
     [ $1 == "debug" ] && export CMAKE_VARS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON"
     [ $1 == "shared_release" ] && export CMAKE_VARS="-DLEATHERMAN_SHARED=ON"
+    [ $1 == "locale_disabled" ] && export CMAKE_VARS="-DLEATHERMAN_USE_LOCALES=OFF"
     cmake $CMAKE_VARS -DCMAKE_INSTALL_PREFIX=$USERDIR ..
     if [ $? -ne 0 ]; then
         echo "cmake failed."
@@ -64,5 +65,6 @@ case $TRAVIS_TARGET in
   "RELEASE" )  travis_make release ;;
   "DEBUG" )    travis_make debug ;;
   "SHARED_RELEASE" ) travis_make shared_release ;;
+  "LOCALE_DISABLED" ) travis_make locale_disabled ;;
   *)           echo "Nothing to do!"
 esac


### PR DESCRIPTION
Code that's only compiled when `LEATHERMAN_USE_LOCALES` is OFF was
incorrect. Fix it and make it more consistent with other code by `using
namespace std`.

Add a Travis run to test this code path.