### PR TITLE
(maint) Add option to skip gettext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ env:
     - TRAVIS_TARGET=DEBUG
     - TRAVIS_TARGET=SHARED_RELEASE
     - TRAVIS_TARGET=LOCALE_DISABLED
+    - TRAVIS_TARGET=GETTEXT_DISABLED
 deploy:
   provider: releases
   api_key:

--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -166,7 +166,7 @@ endmacro()
 # Creates a custom target `translation`.
 macro(gettext_templates dir)
     # Don't even try to find gettext on AIX or Solaris, we don't want it.
-    if (LEATHERMAN_USE_LOCALES)
+    if (LEATHERMAN_USE_LOCALES AND LEATHERMAN_GETTEXT)
         find_program(XGETTEXT_EXE xgettext)
     endif()
 
@@ -237,7 +237,7 @@ endmacro()
 # translation files.
 macro(gettext_compile dir inst)
     # Don't even try to find gettext on AIX or Solaris, we don't want it.
-    if (LEATHERMAN_USE_LOCALES)
+    if (LEATHERMAN_USE_LOCALES AND LEATHERMAN_GETTEXT)
         find_program(MSGFMT_EXE msgfmt)
     endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -14,5 +14,8 @@ else()
 endif()
 defoption(LEATHERMAN_USE_LOCALES "Use locales for internationalization" ${USE_BOOST_LOCALE})
 
+# Provided so it can be disabled temporarily when we don't have gettext built.
+defoption(LEATHERMAN_GETTEXT "Support localization with gettext" ON)
+
 # Map our boost option to the for-realsies one
 set(Boost_USE_STATIC_LIBS ${BOOST_STATIC})

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -15,6 +15,7 @@ function travis_make()
     [ $1 == "debug" ] && export CMAKE_VARS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON"
     [ $1 == "shared_release" ] && export CMAKE_VARS="-DLEATHERMAN_SHARED=ON"
     [ $1 == "locale_disabled" ] && export CMAKE_VARS="-DLEATHERMAN_USE_LOCALES=OFF"
+    [ $1 == "gettext_disabled" ] && export CMAKE_VARS="-DLEATHERMAN_GETTEXT=OFF"
     cmake $CMAKE_VARS -DCMAKE_INSTALL_PREFIX=$USERDIR ..
     if [ $? -ne 0 ]; then
         echo "cmake failed."
@@ -66,5 +67,6 @@ case $TRAVIS_TARGET in
   "DEBUG" )    travis_make debug ;;
   "SHARED_RELEASE" ) travis_make shared_release ;;
   "LOCALE_DISABLED" ) travis_make locale_disabled ;;
+  "GETTEXT_DISABLED" ) travis_make gettext_disabled ;;
   *)           echo "Nothing to do!"
 esac


### PR DESCRIPTION
Adds an option to disable using gettext for generating localization
templates and .mo files. This is the simplest way to avoid build issues
until we have new versions of gettext built on all platforms.