### PR TITLE
(LTH-103) Remove location from .pot files

### DIFF
--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -195,6 +195,7 @@ macro(gettext_templates dir)
                 --keyword=translate_c:1c,2,3
                 --keyword=format
                 --add-comments=LOCALE
+                --no-location
                 ${ALL_PROJECT_SOURCES}
             COMMAND ${CMAKE_COMMAND}
                 -DPOT_FILE=${lang_template}

--- a/locale/locales/fr.po
+++ b/locale/locales/fr.po
@@ -17,26 +17,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: locale/locales/../tests/locale.cc:17 locale/locales/../tests/locale.cc:49
-#: locale/locales/../tests/locale.cc:61 locale/locales/../tests/locale.cc:94
 msgid "requesting {1,number}."
 msgstr "demande {1,number}."
 
-#: locale/locales/../tests/locale.cc:21 locale/locales/../tests/locale.cc:65
 msgctxt "foo"
 msgid "requesting {1,number}."
 msgstr "demandé {1,number}."
 
-#: locale/locales/../tests/locale.cc:27 locale/locales/../tests/locale.cc:31
-#: locale/locales/../tests/locale.cc:35 locale/locales/../tests/locale.cc:72
-#: locale/locales/../tests/locale.cc:76 locale/locales/../tests/locale.cc:80
 msgid "requesting {1,number} item."
 msgid_plural "requesting {1,number} items."
 msgstr[0] "demande {1,number} objet."
 msgstr[1] "demande {1,number} objets."
 
-#: locale/locales/../tests/locale.cc:39 locale/locales/../tests/locale.cc:43
-#: locale/locales/../tests/locale.cc:84 locale/locales/../tests/locale.cc:88
 msgctxt "foo"
 msgid "requesting {1,number} item."
 msgid_plural "requesting {1,number} items."

--- a/locale/locales/leatherman_locale.pot
+++ b/locale/locales/leatherman_locale.pot
@@ -18,34 +18,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: locale/locales/../tests/locale.cc:17
-#: locale/locales/../tests/locale.cc:49
-#: locale/locales/../tests/locale.cc:61
-#: locale/locales/../tests/locale.cc:94
 msgid "requesting {1,number}."
 msgstr ""
 
-#: locale/locales/../tests/locale.cc:21
-#: locale/locales/../tests/locale.cc:65
 msgctxt "foo"
 msgid "requesting {1,number}."
 msgstr ""
 
-#: locale/locales/../tests/locale.cc:27
-#: locale/locales/../tests/locale.cc:31
-#: locale/locales/../tests/locale.cc:35
-#: locale/locales/../tests/locale.cc:72
-#: locale/locales/../tests/locale.cc:76
-#: locale/locales/../tests/locale.cc:80
 msgid "requesting {1,number} item."
 msgid_plural "requesting {1,number} items."
 msgstr[0] ""
 msgstr[1] ""
 
-#: locale/locales/../tests/locale.cc:39
-#: locale/locales/../tests/locale.cc:43
-#: locale/locales/../tests/locale.cc:84
-#: locale/locales/../tests/locale.cc:88
 msgctxt "foo"
 msgid "requesting {1,number} item."
 msgid_plural "requesting {1,number} items."

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -18,421 +18,322 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. debug
-#: curl/src/client.cc:165
 msgid "request completed (status {1})."
 msgstr ""
 
 #. debug
-#: curl/src/client.cc:223
 msgid "requesting {1}."
 msgstr ""
 
 #. warning
-#: curl/src/client.cc:417
 msgid "unexpected HTTP response header: {1}."
 msgstr ""
 
 #. debug
-#: dynamic_library/src/posix/dynamic_library.cc:47
 msgid "library {1} not found {2} ({3})."
 msgstr ""
 
 #. debug
-#: dynamic_library/src/posix/dynamic_library.cc:71
-#: dynamic_library/src/windows/dynamic_library.cc:105
 msgid "library {1} is not loaded when attempting to load symbol {2}."
 msgstr ""
 
 #. debug
-#: dynamic_library/src/posix/dynamic_library.cc:77
-#: dynamic_library/src/windows/dynamic_library.cc:111
 msgid "symbol {1} not found in library {2}, trying alias {3}."
 msgstr ""
 
-#: dynamic_library/src/posix/dynamic_library.cc:82
-#: dynamic_library/src/windows/dynamic_library.cc:116
 msgid "symbol {1} was not found in {2}."
 msgstr ""
 
 #. debug
-#: dynamic_library/src/posix/dynamic_library.cc:84
-#: dynamic_library/src/windows/dynamic_library.cc:118
 msgid "symbol {1} not found in library {2}."
 msgstr ""
 
 #. debug
-#: dynamic_library/src/windows/dynamic_library.cc:26
 msgid ""
 "library matching pattern {1} not found, CreateToolhelp32Snapshot failed: {2}."
 msgstr ""
 
 #. debug
-#: dynamic_library/src/windows/dynamic_library.cc:34
 msgid "library matching pattern {1} not found, Module32First failed: {2}."
 msgstr ""
 
 #. debug
-#: dynamic_library/src/windows/dynamic_library.cc:48
 msgid "library {1} found from pattern {2}"
 msgstr ""
 
 #. debug
-#: dynamic_library/src/windows/dynamic_library.cc:50
 msgid ""
 "library {1} found from pattern {2}, but unloaded before handle was acquired"
 msgstr ""
 
 #. debug
-#: dynamic_library/src/windows/dynamic_library.cc:58
 msgid "no loaded libraries found matching pattern {1}"
 msgstr ""
 
 #. debug
-#: dynamic_library/src/windows/dynamic_library.cc:79
 msgid "library {1} not found {2}."
 msgstr ""
 
 #. debug
-#: execution/src/execution.cc:88
 msgid "executing command: {1}"
 msgstr ""
 
 #. debug
-#: execution/src/execution.cc:425
-#: execution/src/execution.cc:432
 msgid "completed processing output: closing child pipes."
 msgstr ""
 
-#: execution/src/posix/execution.cc:75
-#: windows/src/system_error.cc:23
 msgid "{1} ({2})"
 msgstr ""
 
-#: execution/src/posix/execution.cc:77
 msgid "{1}: {2} ({3})."
 msgstr ""
 
 #. debug
-#: execution/src/posix/execution.cc:223
 msgid "select call was interrupted and will be retried."
 msgstr ""
 
 #. error
-#: execution/src/posix/execution.cc:241
-#: execution/src/windows/execution.cc:300
 msgid "{1} pipe i/o failed: {2}."
 msgstr ""
 
 #. debug
-#: execution/src/posix/execution.cc:245
 msgid "{1} pipe i/o was interrupted and will be retried."
 msgstr ""
 
-#: execution/src/posix/execution.cc:269
-#: execution/src/windows/execution.cc:277
-#: execution/src/windows/execution.cc:352
-#: execution/src/windows/execution.cc:645
 msgid "command timed out after {1} seconds."
 msgstr ""
 
-#: execution/src/posix/execution.cc:362
 msgid "{1}={2}"
 msgstr ""
 
 #. debug
-#: execution/src/posix/execution.cc:413
-#: execution/src/windows/execution.cc:427
 msgid "{1} was not found on the PATH."
 msgstr ""
 
 #. debug
-#: execution/src/posix/execution.cc:553
 msgid "process was signaled with signal {1}."
 msgstr ""
 
 #. debug
-#: execution/src/posix/execution.cc:555
 msgid "process exited with status code {1}."
 msgstr ""
 
-#: execution/src/posix/execution.cc:561
 msgid "child process returned non-zero exit status ({1})."
 msgstr ""
 
-#: execution/src/posix/execution.cc:564
 msgid "child process was terminated by signal ({1})."
 msgstr ""
 
-#: execution/src/windows/execution.cc:127
 msgid "\\\\.\\Pipe\\leatherman.{1}.{2}.{3}.{4}"
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:145
 msgid "failed to create read pipe: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:160
 msgid "failed to create write pipe: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:252
 msgid "failed to create {1} read event: {2}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:345
 msgid "failed to wait for child process i/o: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:368
 msgid "asynchronous i/o on {1} failed: {2}."
 msgstr ""
 
 #. debug
-#: execution/src/windows/execution.cc:451
-#: execution/src/windows/execution.cc:472
 msgid "child environment {1}={2}"
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:558
 msgid "failed to create process: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:580
 msgid "failed to create job object: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:583
 msgid "failed to associate process with job object: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:594
 msgid "failed to terminate process: {1}."
 msgstr ""
 
 #. warning
-#: execution/src/windows/execution.cc:597
 msgid "could not terminate process {1} because a job object could not be used."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:607
 msgid "failed to create waitable timer: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:616
 msgid "failed to set waitable timer: {1}."
 msgstr ""
 
 #. error
-#: execution/src/windows/execution.cc:647
 msgid "failed to wait for child process to terminate: {1}."
 msgstr ""
 
 #. debug
-#: execution/src/windows/execution.cc:657
 msgid "process exited with exit code {1}."
 msgstr ""
 
 #. warning
-#: file_util/src/file.cc:52
 msgid "file path is an empty string"
 msgstr ""
 
 #. debug
-#: file_util/src/file.cc:61
 msgid "Error reading file: {1}"
 msgstr ""
 
 #. warning
-#: file_util/src/file.cc:110
 msgid "{1} has not been set"
 msgstr ""
 
-#: logging/src/logging.cc:201
 msgid ""
 "invalid log level '%1%': expected none, trace, debug, info, warn, error, or "
 "fatal."
 msgstr ""
 
 #. info
-#: ruby/src/api.cc:133
 msgid "ruby loaded from \"{1}\"."
 msgstr ""
 
 #. info
-#: ruby/src/api.cc:135
 msgid "ruby was already loaded."
 msgstr ""
 
 #. info
-#: ruby/src/api.cc:182
 msgid "using ruby version {1}"
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:484
 msgid "preferred ruby library \"{1}\" could not be loaded."
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:494
 msgid "ruby library \"{1}\" could not be loaded."
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:501
 msgid "ruby could not be found on the PATH."
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:504
 msgid "ruby was found at \"{1}\"."
 msgstr ""
 
 #. warning
-#: ruby/src/api.cc:513
 msgid "ruby failed to run: {1}"
 msgstr ""
 
 #. debug
-#: ruby/src/api.cc:519
 msgid ""
 "ruby library \"{1}\" was not found: ensure ruby was built with the --enable-"
 "shared configuration option."
 msgstr ""
 
 #. debug
-#: windows/src/process.cc:27
-#: windows/src/user.cc:50
 msgid "OpenProcessToken call failed: {1}"
 msgstr ""
 
 #. debug
-#: windows/src/process.cc:35
 msgid "GetTokenInformation call failed: {1}"
 msgstr ""
 
-#: windows/src/registry.cc:45
-#: windows/src/registry.cc:53
 msgid "error reading registry key {1} {2}: {3}"
 msgstr ""
 
-#: windows/src/system_error.cc:18
 msgid "unknown error ({1})"
 msgstr ""
 
 #. debug
-#: windows/src/user.cc:29
 msgid "Failed to create administrators SID: {1}"
 msgstr ""
 
 #. debug
-#: windows/src/user.cc:34
 msgid "Invalid SID"
 msgstr ""
 
 #. debug
-#: windows/src/user.cc:40
 msgid "Failed to check membership: {1}"
 msgstr ""
 
 #. debug
-#: windows/src/user.cc:57
 msgid "GetUserProfileDirectoryW call returned unexpectedly"
 msgstr ""
 
 #. debug
-#: windows/src/user.cc:60
-#: windows/src/user.cc:66
 msgid "GetUserProfileDirectoryW call failed: {1}"
 msgstr ""
 
 #. LOCALE: format a pointer as hex for printing an error message.
-#: windows/src/wmi.cc:28
 msgid "{1} (0x{2,num=hex})"
 msgstr ""
 
-#: windows/src/wmi.cc:30
 msgid "%1% (0x%2$#x)"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:40
 msgid "initializing WMI"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:44
 msgid "using prior COM concurrency model"
 msgstr ""
 
-#: windows/src/wmi.cc:49
 msgid "failed to initialize COM library"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:51
 msgid "COM single-threaded apartment not supported, using multi-threaded"
 msgstr ""
 
-#: windows/src/wmi.cc:64
 msgid "failed to create IWbemLocator object"
 msgstr ""
 
-#: windows/src/wmi.cc:72
 msgid "could not connect to WMI server"
 msgstr ""
 
-#: windows/src/wmi.cc:80
 msgid "could not set proxy blanket"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:91
 msgid "ignoring {1}-dimensional array in query {2}.{3}"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:107
 msgid ""
 "WMI query {1}.{2} result could not be converted from type {3} to a string"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:125
 msgid "query {1} failed"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:148
 msgid "query {1}.{2} could not be found"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:171
 msgid "only single value requested from array for key {1}"
 msgstr ""
 
 #. debug
-#: windows/src/wmi.cc:186
-#: windows/src/wmi.cc:198
 msgid "only single entry requested from array of entries for key {1}"
 msgstr ""
 
-#: windows/src/wmi.cc:190
 msgid "unable to get from empty array of objects"
 msgstr ""
 
-#: windows/src/wmi.cc:202
 msgid "unable to get_range from empty array of objects"
 msgstr ""

--- a/logging/locales/fr.po
+++ b/logging/locales/fr.po
@@ -18,55 +18,44 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. debug
-#: logging/locales/../tests/logging_i18n.cc:43
 msgid "debug logging"
 msgstr "l'enregistrement de débogage"
 
 #. debug
-#: logging/locales/../tests/logging_i18n.cc:48
 msgid "debug logging is {1}"
 msgstr "l'enregistrement de débogage est {1}"
 
 #. info
-#: logging/locales/../tests/logging_i18n.cc:53
 msgid "info logging"
 msgstr "info exploitation forestière"
 
 #. info
-#: logging/locales/../tests/logging_i18n.cc:58
 msgid "info logging is {1}"
 msgstr "info exploitation forestière est {1}"
 
 #. warning
-#: logging/locales/../tests/logging_i18n.cc:63
 msgid "warning logging"
 msgstr "journalisation d'avertissement"
 
 #. warning
-#: logging/locales/../tests/logging_i18n.cc:68
 msgid "warning logging is {1}"
 msgstr "journalisation d'avertissement est {1}"
 
 #. error
-#: logging/locales/../tests/logging_i18n.cc:73
 msgid "error message"
 msgstr "message d'erreur"
 
 #. error
-#: logging/locales/../tests/logging_i18n.cc:78
 msgid "error message is {1}"
 msgstr "un message d'erreur est {1}"
 
 #. fatal
-#: logging/locales/../tests/logging_i18n.cc:83
 msgid "fatal message"
 msgstr "un message fatal"
 
 #. fatal
-#: logging/locales/../tests/logging_i18n.cc:88
 msgid "fatal message is {1}"
 msgstr "un message fatal est {1}"
 
-#: logging/locales/../tests/logging_i18n.cc:93
 msgid "™❄Λ"
 msgstr "Λ❄™"

--- a/logging/locales/leatherman_logging.pot
+++ b/logging/locales/leatherman_logging.pot
@@ -18,55 +18,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. debug
-#: logging/locales/../tests/logging_i18n.cc:43
 msgid "debug logging"
 msgstr ""
 
 #. debug
-#: logging/locales/../tests/logging_i18n.cc:48
 msgid "debug logging is {1}"
 msgstr ""
 
 #. info
-#: logging/locales/../tests/logging_i18n.cc:53
 msgid "info logging"
 msgstr ""
 
 #. info
-#: logging/locales/../tests/logging_i18n.cc:58
 msgid "info logging is {1}"
 msgstr ""
 
 #. warning
-#: logging/locales/../tests/logging_i18n.cc:63
 msgid "warning logging"
 msgstr ""
 
 #. warning
-#: logging/locales/../tests/logging_i18n.cc:68
 msgid "warning logging is {1}"
 msgstr ""
 
 #. error
-#: logging/locales/../tests/logging_i18n.cc:73
 msgid "error message"
 msgstr ""
 
 #. error
-#: logging/locales/../tests/logging_i18n.cc:78
 msgid "error message is {1}"
 msgstr ""
 
 #. fatal
-#: logging/locales/../tests/logging_i18n.cc:83
 msgid "fatal message"
 msgstr ""
 
 #. fatal
-#: logging/locales/../tests/logging_i18n.cc:88
 msgid "fatal message is {1}"
 msgstr ""
 
-#: logging/locales/../tests/logging_i18n.cc:93
 msgid "™❄Λ"
 msgstr ""


### PR DESCRIPTION
Adding location to gettext .pot files makes it time-consuming to merge
changes, and adds a lot of noise to commits. Remove it.