### PR TITLE
(FACT-1454) Fix Leatherman cleanup of Ruby objects

### DIFF
--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -195,6 +195,11 @@ namespace leatherman { namespace ruby {
 
     void api::uninitialize()
     {
+        if (_initialized && _library.first_load()) {
+            ruby_cleanup(0);
+            _initialized = false;
+        }
+
         // API is shutting down; free all remaining data objects
         // Destructors may unregister the data object, so increment the iterator before freeing
         for (auto it = _data_objects.begin(); it != _data_objects.end();) {
@@ -203,14 +208,10 @@ namespace leatherman { namespace ruby {
             if (data->dfree) {
                 data->dfree(data->data);
                 data->dfree = nullptr;
+                data->dmark = nullptr;
             }
         }
         _data_objects.clear();
-
-        if (_initialized && _library.first_load()) {
-            ruby_cleanup(0);
-            _initialized = false;
-        }
     }
 
     bool api::include_stack_trace() const


### PR DESCRIPTION
Leatherman must call ruby_cleanup() first to destroy objects managed by the Ruby garbage collector, followed by manual destruction of any remaining objects. Prior to Ruby 2.3, ruby_cleanup() did not initiate garbage collection.