### PR TITLE
(LTH-107) Add inherit_locale option to execute

### DIFF
--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -61,6 +61,12 @@ namespace leatherman { namespace execution {
          */
         create_new_process_group = (1 << 8),
         /**
+         * Inherit locale environment variables from the current process. Limited to LC_ALL and
+         * LOCALE, which are specifically overridden to "C" with merge_environment.
+         * Will not override those variables if explicitly passed in an environment map.
+         */
+        inherit_locale = (1 << 9),
+        /**
          * A combination of all throw options.
          */
         throw_on_failure = throw_on_nonzero_exit | throw_on_signal,

--- a/util/inc/leatherman/util/scoped_env.hpp
+++ b/util/inc/leatherman/util/scoped_env.hpp
@@ -17,11 +17,16 @@ namespace leatherman { namespace util {
     struct scoped_env : scoped_resource<std::tuple<std::string, boost::optional<std::string>>>
     {
         /**
-         * Constructs a scoped_env from the specified error code.
+         * Temporarily overrides the value of an environment variable.
          * @param var    The environment variable to update.
          * @param newval The value to set it to during existence of this object.
          */
         explicit scoped_env(std::string var, std::string const& newval);
+
+        /**
+         * Temporarily unsets an environment variable.
+         */
+        explicit scoped_env(std::string var);
 
      private:
         static void restore(std::tuple<std::string, boost::optional<std::string>> &);

--- a/util/src/scoped_env.cc
+++ b/util/src/scoped_env.cc
@@ -15,6 +15,16 @@ namespace leatherman { namespace util {
         _deleter = scoped_env::restore;
     }
 
+    scoped_env::scoped_env(string var) : scoped_resource()
+    {
+        string oldval;
+        bool was_set = environment::get(var, oldval);
+        environment::clear(var);
+
+        _resource = make_tuple(move(var), was_set ? boost::optional<std::string>(move(oldval)) : boost::none);
+        _deleter = scoped_env::restore;
+    }
+
     void scoped_env::restore(tuple<string, boost::optional<std::string>> & old)
     {
         if (get<1>(old)) {

--- a/util/tests/scoped_env.cc
+++ b/util/tests/scoped_env.cc
@@ -18,6 +18,12 @@ SCENARIO("scoping an environment variable") {
                 REQUIRE(value == "FOO");
             }
         }
+        AND_WHEN("the variable is scoped as unset") {
+            scoped_env foo("LEATH_ENV_TEST");
+            THEN("the variable is not set") {
+                REQUIRE_FALSE(environment::get("LEATH_ENV_TEST", value));
+            }
+        }
     }
     WHEN("the variable exists")
     {
@@ -28,6 +34,12 @@ SCENARIO("scoping an environment variable") {
             THEN("the new value is set") {
                 REQUIRE(environment::get("LEATH_ENV_TEST", value));
                 REQUIRE(value == "FOO");
+            }
+        }
+        AND_WHEN("the variable is scoped as unset") {
+            scoped_env foo("LEATH_ENV_TEST");
+            THEN("the variable is not set") {
+                REQUIRE_FALSE(environment::get("LEATH_ENV_TEST", value));
             }
         }
         THEN("the variable should be restored") {


### PR DESCRIPTION
The `execute` function was originally implemented for Facter calls to
command-line tools, where it wants consistently parseable output. For
that purpose, it always overrode LC_ALL and LANG.

We now use `execute` for other purposes, so allow inheriting the locale
from the executing process.