### PR TITLE
(LTH-59) Review and mark translatable strings in Leatherman

### DIFF
--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -3,9 +3,13 @@
 #include <leatherman/curl/response.hpp>
 #include <leatherman/util/regex.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <boost/algorithm/string.hpp>
 #include <sstream>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 using namespace std;
 
@@ -76,7 +80,7 @@ namespace leatherman { namespace curl {
     {
         _resource = curl_easy_escape(handle, str.c_str(), str.size());
         if (!_resource) {
-            throw http_exception("curl_easy_escape failed to escape string.");
+            throw http_exception(_("curl_easy_escape failed to escape string."));
         }
     }
 
@@ -90,7 +94,7 @@ namespace leatherman { namespace curl {
     client::client()
     {
         if (!_handle) {
-            throw http_exception("failed to create cURL handle.");
+            throw http_exception(_("failed to create cURL handle."));
         }
     }
 
@@ -208,7 +212,7 @@ namespace leatherman { namespace curl {
             }
 
             default:
-                throw http_request_exception(ctx.req, "unexpected HTTP method specified.");
+                throw http_request_exception(ctx.req, _("unexpected HTTP method specified."));
         }
     }
 

--- a/dynamic_library/src/windows/dynamic_library.cc
+++ b/dynamic_library/src/windows/dynamic_library.cc
@@ -4,8 +4,12 @@
 #include <leatherman/windows/system_error.hpp>
 #include <leatherman/windows/windows.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
 #include <boost/nowide/convert.hpp>
 #include <tlhelp32.h>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 using namespace std;
 using namespace leatherman::util;
@@ -100,7 +104,7 @@ namespace leatherman { namespace dynamic_library {
     {
         if (!_handle) {
             if (throw_if_missing) {
-                throw missing_import_exception("library is not loaded");
+                throw missing_import_exception(_("library is not loaded"));
             } else {
                 LOG_DEBUG("library {1} is not loaded when attempting to load symbol {2}.", _name.c_str(), name.c_str());
             }
@@ -113,7 +117,7 @@ namespace leatherman { namespace dynamic_library {
         }
         if (!symbol) {
             if (throw_if_missing) {
-                throw missing_import_exception(lth_locale::format("symbol {1} was not found in {2}.", name, _name));
+                throw missing_import_exception(_("symbol {1} was not found in {2}.", name, _name));
             } else {
                 LOG_DEBUG("symbol {1} not found in library {2}.", name.c_str(), _name.c_str());
             }

--- a/execution/src/execution.cc
+++ b/execution/src/execution.cc
@@ -1,5 +1,6 @@
 #include <leatherman/execution/execution.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/nowide/fstream.hpp>
@@ -7,6 +8,9 @@
 #include <cstdio>
 #include <sstream>
 #include <cstring>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 using namespace std;
 using namespace leatherman::logging;
@@ -257,7 +261,7 @@ namespace leatherman { namespace execution {
 
         out_stream.open(out_file.c_str(), std::ios::binary);
         if (!out_stream.is_open()) {
-            throw execution_exception("failed to open the output file.");
+            throw execution_exception(_("failed to open the output file."));
         }
 
         if (err_file.empty()) {
@@ -265,7 +269,7 @@ namespace leatherman { namespace execution {
         } else {
             err_stream.open(err_file.c_str(), std::ios::binary);
             if (!err_stream.is_open()) {
-                throw execution_exception("failed to open the error file.");
+                throw execution_exception(_("failed to open the error file."));
             }
 
             stderr_callback = ([&](string& line) {

--- a/execution/src/windows/execution.cc
+++ b/execution/src/windows/execution.cc
@@ -6,6 +6,7 @@
 #include <leatherman/windows/system_error.hpp>
 #include <leatherman/windows/windows.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/nowide/convert.hpp>
@@ -18,6 +19,9 @@
 #include <cstring>
 #include <random>
 
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
 using namespace std;
 using namespace leatherman::windows;
 using namespace leatherman::logging;
@@ -25,7 +29,6 @@ using namespace leatherman::util;
 using namespace leatherman::util::windows;
 using namespace boost::filesystem;
 using namespace boost::algorithm;
-namespace lth_locale = leatherman::locale;
 
 namespace leatherman { namespace execution {
 
@@ -124,7 +127,7 @@ namespace leatherman { namespace execution {
         // but the other end doesn't release. Then the invoking thread shuts down and another with
         // the same thread id is started and reconnects to the existing named pipe. Use the process
         // id and a random UUID to make that highly unlikely.
-        wstring name = boost::nowide::widen(lth_locale::format("\\\\.\\Pipe\\leatherman.{1}.{2}.{3}.{4}",
+        wstring name = boost::nowide::widen(_("\\\\.\\Pipe\\leatherman.{1}.{2}.{3}.{4}",
             GetCurrentProcessId(),
             GetCurrentThreadId(),
             InterlockedIncrement(&counter),
@@ -143,7 +146,7 @@ namespace leatherman { namespace execution {
 
         if (read_handle == INVALID_HANDLE_VALUE) {
             LOG_ERROR("failed to create read pipe: {1}.", windows::system_error());
-            throw execution_exception("failed to create read pipe.");
+            throw execution_exception(_("failed to create read pipe."));
         }
 
         // Open the write pipe
@@ -158,7 +161,7 @@ namespace leatherman { namespace execution {
 
         if (write_handle == INVALID_HANDLE_VALUE) {
             LOG_ERROR("failed to create write pipe: {1}.", windows::system_error());
-            throw execution_exception("failed to create write pipe.");
+            throw execution_exception(_("failed to create write pipe."));
         }
 
         return make_tuple(move(read_handle), move(write_handle));
@@ -250,7 +253,7 @@ namespace leatherman { namespace execution {
                 event = scoped_handle(CreateEvent(nullptr, TRUE, FALSE, nullptr));
                 if (!event) {
                     LOG_ERROR("failed to create {1} read event: {2}.", name, windows::system_error());
-                    throw execution_exception("failed to create read event.");
+                    throw execution_exception(_("failed to create read event."));
                 }
                 overlapped.hEvent = event;
             }
@@ -274,7 +277,7 @@ namespace leatherman { namespace execution {
                     // Before doing anything, check to see if there's been a timeout
                     // This is done pre-emptively in case ReadFile never returns ERROR_IO_PENDING
                     if (timeout && WaitForSingleObject(timer, 0) == WAIT_OBJECT_0) {
-                        throw timeout_exception(lth_locale::format("command timed out after {1} seconds.", timeout), static_cast<size_t>(child));
+                        throw timeout_exception(_("command timed out after {1} seconds.", timeout), static_cast<size_t>(child));
                     }
 
                     if (pipe.read) {
@@ -298,7 +301,7 @@ namespace leatherman { namespace execution {
                             break;
                         }
                         LOG_ERROR("{1} pipe i/o failed: {2}.", pipe.name, windows::system_error());
-                        throw execution_exception("child i/o failed.");
+                        throw execution_exception(_("child i/o failed."));
                     }
 
                     // Check for closed pipe
@@ -343,13 +346,13 @@ namespace leatherman { namespace execution {
             auto result = WaitForMultipleObjects(wait_handles.size(), wait_handles.data(), FALSE, INFINITE);
             if (result >= (WAIT_OBJECT_0 + wait_handles.size())) {
                 LOG_ERROR("failed to wait for child process i/o: {1}.", windows::system_error());
-                throw execution_exception("failed to wait for child process i/o.");
+                throw execution_exception(_("failed to wait for child process i/o."));
             }
 
             // Check for timeout
             DWORD index = result - WAIT_OBJECT_0;
             if (timeout && wait_handles[index] == timer) {
-                throw timeout_exception(lth_locale::format("command timed out after {1} seconds.", timeout), static_cast<size_t>(child));
+                throw timeout_exception(_("command timed out after {1} seconds.", timeout), static_cast<size_t>(child));
             }
 
             // Find the pipe for the event that was signalled
@@ -366,7 +369,7 @@ namespace leatherman { namespace execution {
                 if (!GetOverlappedResult(pipe.handle, &pipe.overlapped, &count, FALSE)) {
                     if (GetLastError() != ERROR_BROKEN_PIPE) {
                         LOG_ERROR("asynchronous i/o on {1} failed: {2}.", pipe.name, windows::system_error());
-                        throw execution_exception("asynchronous i/o failed.");
+                        throw execution_exception(_("asynchronous i/o failed."));
                     }
                     // Treat a broken pipe as nothing left to read
                     count = 0;
@@ -410,7 +413,7 @@ namespace leatherman { namespace execution {
         BOOL in_job;
         bool use_job_object = true;
         if (!IsProcessInJob(GetCurrentProcess(), nullptr, &in_job)) {
-            throw execution_exception("could not determine if the parent process is running in a job object");
+            throw execution_exception(_("could not determine if the parent process is running in a job object"));
         }
         if (in_job) {
             JOBOBJECT_BASIC_LIMIT_INFORMATION limits;
@@ -426,7 +429,7 @@ namespace leatherman { namespace execution {
         if (executable.empty()) {
             LOG_DEBUG("{1} was not found on the PATH.", file);
             if (options[execution_options::throw_on_nonzero_exit]) {
-                throw child_exit_exception("child process returned non-zero exit status.", 127, {}, {});
+                throw child_exit_exception(_("child process returned non-zero exit status."), 127, {}, {});
             }
             return {false, "", "", 127, 0};
         }
@@ -503,13 +506,13 @@ namespace leatherman { namespace execution {
         scoped_handle stdInRd, stdInWr;
         tie(stdInRd, stdInWr) = CreatePipeThrow();
         if (!SetHandleInformation(stdInWr, HANDLE_FLAG_INHERIT, 0)) {
-            throw execution_exception("pipe could not be modified");
+            throw execution_exception(_("pipe could not be modified"));
         }
 
         scoped_handle stdOutRd, stdOutWr;
         tie(stdOutRd, stdOutWr) = CreatePipeThrow();
         if (!SetHandleInformation(stdOutRd, HANDLE_FLAG_INHERIT, 0)) {
-            throw execution_exception("pipe could not be modified");
+            throw execution_exception(_("pipe could not be modified"));
         }
 
         scoped_handle stdErrRd, stdErrWr;
@@ -521,13 +524,13 @@ namespace leatherman { namespace execution {
                 attributes.bInheritHandle = TRUE;
                 stdErrWr = scoped_handle(CreateFileW(L"nul", GENERIC_WRITE, FILE_SHARE_WRITE, &attributes, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
                 if (stdErrWr == INVALID_HANDLE_VALUE) {
-                    throw execution_exception("cannot open NUL device for redirecting stderr.");
+                    throw execution_exception(_("cannot open NUL device for redirecting stderr."));
                 }
             } else {
                 // Otherwise, we're reading from stderr, so create a pipe
                 tie(stdErrRd, stdErrWr) = CreatePipeThrow();
                 if (!SetHandleInformation(stdErrRd, HANDLE_FLAG_INHERIT, 0)) {
-                    throw execution_exception("pipe could not be modified");
+                    throw execution_exception(_("pipe could not be modified"));
                 }
             }
         }
@@ -574,7 +577,7 @@ namespace leatherman { namespace execution {
             &startupInfo,   /* STARTUPINFO for child process */
             &procInfo)) {   /* PROCESS_INFORMATION pointer for output */
             LOG_ERROR("failed to create process: {1}.", windows::system_error());
-            throw execution_exception("failed to create child process.");
+            throw execution_exception(_("failed to create child process."));
         }
 
         // Release unused pipes, to avoid any races in process completion.
@@ -596,10 +599,10 @@ namespace leatherman { namespace execution {
             hJob = scoped_handle(CreateJobObjectW(nullptr, nullptr));
             if (hJob == NULL) {
                 LOG_ERROR("failed to create job object: {1}.", windows::system_error());
-                throw execution_exception("failed to create job object.");
+                throw execution_exception(_("failed to create job object."));
             } else if (!AssignProcessToJobObject(hJob, hProcess)) {
                 LOG_ERROR("failed to associate process with job object: {1}.", windows::system_error());
-                throw execution_exception("failed to associate process with job object.");
+                throw execution_exception(_("failed to associate process with job object."));
             }
         }
 
@@ -623,7 +626,7 @@ namespace leatherman { namespace execution {
             timer = scoped_handle(CreateWaitableTimer(nullptr, TRUE, nullptr));
             if (!timer) {
                 LOG_ERROR("failed to create waitable timer: {1}.", windows::system_error());
-                throw execution_exception("failed to create waitable timer.");
+                throw execution_exception(_("failed to create waitable timer."));
             }
 
             // "timeout" in X intervals in the future (1 interval = 100 ns)
@@ -632,7 +635,7 @@ namespace leatherman { namespace execution {
             future.QuadPart = timeout * -10000000ll;
             if (!SetWaitableTimer(timer, &future, 0, nullptr, nullptr, FALSE)) {
                 LOG_ERROR("failed to set waitable timer: {1}.", windows::system_error());
-                throw execution_exception("failed to set waitable timer.");
+                throw execution_exception(_("failed to set waitable timer."));
             }
         }
 
@@ -660,22 +663,22 @@ namespace leatherman { namespace execution {
             terminate = false;
         } else if (wait_result == WAIT_OBJECT_0 + 1) {
             // Timeout while waiting on the process to complete
-            throw timeout_exception(lth_locale::format("command timed out after {1} seconds.", timeout), static_cast<size_t>(procInfo.dwProcessId));
+            throw timeout_exception(_("command timed out after {1} seconds.", timeout), static_cast<size_t>(procInfo.dwProcessId));
         } else {
             LOG_ERROR("failed to wait for child process to terminate: {1}.", windows::system_error());
-            throw execution_exception("failed to wait for child process to terminate.");
+            throw execution_exception(_("failed to wait for child process to terminate."));
         }
 
         // Now check the process return status.
         DWORD exit_code;
         if (!GetExitCodeProcess(hProcess, &exit_code)) {
-            throw execution_exception("error retrieving exit code of completed process");
+            throw execution_exception(_("error retrieving exit code of completed process"));
         }
 
         LOG_DEBUG("process exited with exit code {1}.", exit_code);
 
         if (exit_code != 0 && options[execution_options::throw_on_nonzero_exit]) {
-            throw child_exit_exception("child process returned non-zero exit status.", exit_code, output, error);
+            throw child_exit_exception(_("child process returned non-zero exit status."), exit_code, output, error);
         }
         return {exit_code == 0, move(output), move(error), static_cast<int>(exit_code), static_cast<size_t>(procInfo.dwProcessId)};
     }

--- a/file_util/src/file.cc
+++ b/file_util/src/file.cc
@@ -4,6 +4,10 @@
 #include <boost/filesystem.hpp>
 #include <sstream>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 using namespace std;
 
@@ -72,7 +76,7 @@ namespace boost_file = boost::filesystem;
         std::string tmp_name = file_path + "~";
         ofs.open(tmp_name.c_str(), mode);
         if (!ofs.is_open()) {
-            throw boost_file::filesystem_error { "failed to open " + file_path,
+            throw boost_file::filesystem_error { _("failed to open {1}", file_path),
                                                         boost_error::make_error_code(
                                                                 boost_error::io_error) };
         }

--- a/json_container/CMakeLists.txt
+++ b/json_container/CMakeLists.txt
@@ -1,4 +1,10 @@
+find_package(Boost 1.54 REQUIRED COMPONENTS regex)
+
+add_leatherman_deps("${Boost_LIBRARIES}")
+add_leatherman_includes("${Boost_INCLUDE_DIRS}")
+
 leatherman_dependency(rapidjson)
+leatherman_dependency(locale)
 
 add_leatherman_library("src/json_container.cc")
 add_leatherman_headers("inc/leatherman")

--- a/json_container/inc/leatherman/json_container/json_container.hpp
+++ b/json_container/inc/leatherman/json_container/json_container.hpp
@@ -6,6 +6,10 @@
 #include <tuple>
 #include <typeinfo>
 #include <memory>
+#include <leatherman/locale/locale.hpp>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 // Forward declarations for rapidjson
 namespace rapidjson {
@@ -259,7 +263,7 @@ namespace leatherman { namespace json_container {
             auto key_data = key.data();
 
             if (!isObject(*jval)) {
-                throw data_type_error { "not an object" };
+                throw data_type_error { _("not an object") };
             }
 
             if (!hasKey(*jval, key_data)) {
@@ -281,7 +285,7 @@ namespace leatherman { namespace json_container {
             auto jval_obj = getValueInJson(keys.cbegin(), keys.cend()-1);
 
             if (!isObject(*jval_obj)) {
-                throw data_type_error { "not an object" };
+                throw data_type_error { _("not an object") };
             }
 
             if (!hasKey(*jval_obj, key_data)) {
@@ -299,7 +303,7 @@ namespace leatherman { namespace json_container {
             auto key_data = key.data();
 
             if (!isObject(*jval)) {
-                throw data_key_error { "root is not a valid JSON object" };
+                throw data_key_error { _("root is not a valid JSON object") };
             }
 
             if (!hasKey(*jval, key_data)) {
@@ -320,8 +324,7 @@ namespace leatherman { namespace json_container {
                 const char* key_data = key.data();
 
                 if (!isObject(*jval)) {
-                    throw data_key_error { "invalid key supplied; cannot "
-                                           "navigate the provided path" };
+                    throw data_key_error { _("invalid key supplied; cannot navigate the provided path") };
                 }
 
                 if (!hasKey(*jval, key_data)) {

--- a/json_container/src/json_container.cc
+++ b/json_container/src/json_container.cc
@@ -1,10 +1,14 @@
 #include <leatherman/json_container/json_container.hpp>
+#include <leatherman/locale/locale.hpp>
 
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 #include <rapidjson/allocators.h>
 #include <rapidjson/rapidjson.h>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 namespace leatherman { namespace json_container {
 
@@ -34,7 +38,7 @@ namespace leatherman { namespace json_container {
         document_root_->Parse(json_text.data());
 
         if (document_root_->HasParseError()) {
-            throw data_parse_error { "invalid json" };
+            throw data_parse_error { _("invalid json") };
         }
     }
 
@@ -301,12 +305,11 @@ namespace leatherman { namespace json_container {
     json_value* JsonContainer::getValueInJson(const json_value& jval,
                                                     const char* key) const {
         if (!jval.IsObject()) {
-            throw data_type_error { "not an object" };
+            throw data_type_error { _("not an object") };
         }
 
         if (!jval.HasMember(key)) {
-            std::string err_msg { "unknown object entry with key: " };
-            throw data_key_error { err_msg + key };
+            throw data_key_error { _("unknown object entry with key: {1}", key) };
         }
 
         return const_cast<json_value*>(&jval[key]);
@@ -315,11 +318,11 @@ namespace leatherman { namespace json_container {
     json_value* JsonContainer::getValueInJson(const json_value& jval,
                                                     const size_t& idx) const {
         if (getValueType(jval) != DataType::Array) {
-            throw data_type_error { "not an array" };
+            throw data_type_error { _("not an array") };
         }
 
         if (idx >= jval.Size()) {
-            throw data_index_error { "array index out of bounds" };
+            throw data_index_error { _("array index out of bounds") };
         }
 
         return const_cast<json_value*>(&jval[idx]);
@@ -358,7 +361,7 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsInt()) {
-            throw data_type_error { "not an integer" };
+            throw data_type_error { _("not an integer") };
         }
 
         return value.GetInt();
@@ -371,7 +374,7 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsBool()) {
-            throw data_type_error { "not a boolean" };
+            throw data_type_error { _("not a boolean") };
         }
 
         return value.GetBool();
@@ -384,7 +387,7 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsString()) {
-            throw data_type_error { "not a string" };
+            throw data_type_error { _("not a string") };
         }
 
         return std::string(value.GetString());
@@ -397,7 +400,7 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsDouble()) {
-            throw data_type_error { "not a double" };
+            throw data_type_error { _("not a double") };
         }
 
         return value.GetDouble();
@@ -433,14 +436,14 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsArray()) {
-            throw data_type_error { "not an array" };
+            throw data_type_error { _("not an array") };
         }
 
         for (json_value::ConstValueIterator itr = value.Begin();
              itr != value.End();
              itr++) {
             if (!itr->IsString()) {
-                throw data_type_error { "not a string" };
+                throw data_type_error { _("not a string") };
             }
 
             tmp.push_back(itr->GetString());
@@ -458,14 +461,14 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsArray()) {
-            throw data_type_error { "not an array" };
+            throw data_type_error { _("not an array") };
         }
 
         for (json_value::ConstValueIterator itr = value.Begin();
              itr != value.End();
              itr++) {
             if (!itr->IsBool()) {
-                throw data_type_error { "not a boolean" };
+                throw data_type_error { _("not a boolean") };
             }
 
             tmp.push_back(itr->GetBool());
@@ -483,14 +486,14 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsArray()) {
-            throw data_type_error { "not an array" };
+            throw data_type_error { _("not an array") };
         }
 
         for (json_value::ConstValueIterator itr = value.Begin();
              itr != value.End();
              itr++) {
             if (!itr->IsInt()) {
-                throw data_type_error { "not an integer" };
+                throw data_type_error { _("not an integer") };
             }
 
             tmp.push_back(itr->GetInt());
@@ -508,14 +511,14 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsArray()) {
-            throw data_type_error { "not an array" };
+            throw data_type_error { _("not an array") };
         }
 
         for (json_value::ConstValueIterator itr = value.Begin();
              itr != value.End();
              itr++) {
             if (!itr->IsDouble()) {
-                throw data_type_error { "not a double" };
+                throw data_type_error { _("not a double") };
             }
 
             tmp.push_back(itr->GetDouble());
@@ -533,14 +536,14 @@ namespace leatherman { namespace json_container {
         }
 
         if (!value.IsArray()) {
-            throw data_type_error { "not an array" };
+            throw data_type_error { _("not an array") };
         }
 
         for (json_value::ConstValueIterator itr = value.Begin();
              itr != value.End();
              itr++) {
             if (!itr->IsObject()) {
-                throw data_type_error { "not an object" };
+                throw data_type_error { _("not an object") };
             }
 
             JsonContainer* tmp_this = const_cast<JsonContainer*>(this);

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.8.1\n"
+"Project-Id-Version: leatherman 0.9.0\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -17,9 +17,21 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: curl/src/client.cc
+msgid "curl_easy_escape failed to escape string."
+msgstr ""
+
+#: curl/src/client.cc
+msgid "failed to create cURL handle."
+msgstr ""
+
 #. debug
 #: curl/src/client.cc
 msgid "request completed (status {1})."
+msgstr ""
+
+#: curl/src/client.cc
+msgid "unexpected HTTP method specified."
 msgstr ""
 
 #. debug
@@ -92,9 +104,21 @@ msgstr ""
 msgid "library {1} not found {2}."
 msgstr ""
 
+#: dynamic_library/src/windows/dynamic_library.cc
+msgid "library is not loaded"
+msgstr ""
+
 #. debug
 #: execution/src/execution.cc
 msgid "executing command: {1}"
+msgstr ""
+
+#: execution/src/execution.cc
+msgid "failed to open the output file."
+msgstr ""
+
+#: execution/src/execution.cc
+msgid "failed to open the error file."
 msgstr ""
 
 #. debug
@@ -109,6 +133,15 @@ msgstr ""
 
 #: execution/src/posix/execution.cc
 msgid "{1}: {2} ({3})."
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "select call failed"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+#: execution/src/windows/execution.cc
+msgid "child i/o failed."
 msgstr ""
 
 #. debug
@@ -133,13 +166,66 @@ msgid "command timed out after {1} seconds."
 msgstr ""
 
 #: execution/src/posix/execution.cc
+msgid "failed to setpgid."
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to redirect child stdin."
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to redirect child stdout."
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to redirect child stderr."
+msgstr ""
+
+#: execution/src/posix/execution.cc
 msgid "{1}={2}"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to fork child process"
 msgstr ""
 
 #. debug
 #: execution/src/posix/execution.cc
 #: execution/src/windows/execution.cc
 msgid "{1} was not found on the PATH."
+msgstr ""
+
+#: execution/src/posix/execution.cc
+#: execution/src/windows/execution.cc
+msgid "child process returned non-zero exit status."
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to allocate pipe for stdin redirection"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to allocate pipe for stdout redirection"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to allocate pipe for stderr redirection"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "waitpid failed"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "sigaction failed"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "failed to setup timer"
+msgstr ""
+
+#: execution/src/posix/execution.cc
+msgid "setitimer failed"
 msgstr ""
 
 #. debug
@@ -169,9 +255,17 @@ msgstr ""
 msgid "failed to create read pipe: {1}."
 msgstr ""
 
+#: execution/src/windows/execution.cc
+msgid "failed to create read pipe."
+msgstr ""
+
 #. error
 #: execution/src/windows/execution.cc
 msgid "failed to create write pipe: {1}."
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "failed to create write pipe."
 msgstr ""
 
 #. error
@@ -179,9 +273,17 @@ msgstr ""
 msgid "failed to create {1} read event: {2}."
 msgstr ""
 
+#: execution/src/windows/execution.cc
+msgid "failed to create read event."
+msgstr ""
+
 #. error
 #: execution/src/windows/execution.cc
 msgid "failed to wait for child process i/o: {1}."
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "failed to wait for child process i/o."
 msgstr ""
 
 #. error
@@ -189,9 +291,25 @@ msgstr ""
 msgid "asynchronous i/o on {1} failed: {2}."
 msgstr ""
 
+#: execution/src/windows/execution.cc
+msgid "asynchronous i/o failed."
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "could not determine if the parent process is running in a job object"
+msgstr ""
+
 #. debug
 #: execution/src/windows/execution.cc
 msgid "child environment {1}={2}"
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "pipe could not be modified"
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "cannot open NUL device for redirecting stderr."
 msgstr ""
 
 #. error
@@ -199,14 +317,26 @@ msgstr ""
 msgid "failed to create process: {1}."
 msgstr ""
 
+#: execution/src/windows/execution.cc
+msgid "failed to create child process."
+msgstr ""
+
 #. error
 #: execution/src/windows/execution.cc
 msgid "failed to create job object: {1}."
 msgstr ""
 
+#: execution/src/windows/execution.cc
+msgid "failed to create job object."
+msgstr ""
+
 #. error
 #: execution/src/windows/execution.cc
 msgid "failed to associate process with job object: {1}."
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "failed to associate process with job object."
 msgstr ""
 
 #. error
@@ -224,14 +354,30 @@ msgstr ""
 msgid "failed to create waitable timer: {1}."
 msgstr ""
 
+#: execution/src/windows/execution.cc
+msgid "failed to create waitable timer."
+msgstr ""
+
 #. error
 #: execution/src/windows/execution.cc
 msgid "failed to set waitable timer: {1}."
 msgstr ""
 
+#: execution/src/windows/execution.cc
+msgid "failed to set waitable timer."
+msgstr ""
+
 #. error
 #: execution/src/windows/execution.cc
 msgid "failed to wait for child process to terminate: {1}."
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "failed to wait for child process to terminate."
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "error retrieving exit code of completed process"
 msgstr ""
 
 #. debug
@@ -249,15 +395,68 @@ msgstr ""
 msgid "Error reading file: {1}"
 msgstr ""
 
+#: file_util/src/file.cc
+msgid "failed to open {1}"
+msgstr ""
+
 #. warning
 #: file_util/src/file.cc
 msgid "{1} has not been set"
 msgstr ""
 
+#: json_container/inc/leatherman/json_container/json_container.hpp
+#: json_container/src/json_container.cc
+msgid "not an object"
+msgstr ""
+
+#: json_container/inc/leatherman/json_container/json_container.hpp
+msgid "root is not a valid JSON object"
+msgstr ""
+
+#: json_container/inc/leatherman/json_container/json_container.hpp
+msgid "invalid key supplied; cannot navigate the provided path"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "invalid json"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "unknown object entry with key: {1}"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "not an array"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "array index out of bounds"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "not an integer"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "not a boolean"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "not a string"
+msgstr ""
+
+#: json_container/src/json_container.cc
+msgid "not a double"
+msgstr ""
+
 #: logging/src/logging.cc
 msgid ""
-"invalid log level '%1%': expected none, trace, debug, info, warn, error, or "
+"invalid log level '{1}': expected none, trace, debug, info, warn, error, or "
 "fatal."
+msgstr ""
+
+#: ruby/src/api.cc
+msgid "could not locate a ruby library"
 msgstr ""
 
 #. info
@@ -273,6 +472,14 @@ msgstr ""
 #. info
 #: ruby/src/api.cc
 msgid "using ruby version {1}"
+msgstr ""
+
+#: ruby/src/api.cc
+msgid "size_t maximum exceeded, requested size was {1}"
+msgstr ""
+
+#: ruby/src/api.cc
+msgid "maximum array size exceeded, reported size was {1}"
 msgstr ""
 
 #. warning
@@ -320,6 +527,10 @@ msgstr ""
 #. debug
 #: windows/src/process.cc
 msgid "GetTokenInformation call failed: {1}"
+msgstr ""
+
+#: windows/src/registry.cc
+msgid "invalid HKEY specified"
 msgstr ""
 
 #: windows/src/registry.cc

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -2,6 +2,9 @@
 #include <leatherman/locale/locale.hpp>
 #include <vector>
 
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
 // boost includes are not always warning-clean. Disable warnings that
 // cause problems before including the headers, then re-enable the warnings.
 #pragma GCC diagnostic push
@@ -198,7 +201,7 @@ namespace leatherman { namespace logging {
                 return in;
             }
         }
-        throw runtime_error(lth_locale::format("invalid log level '%1%': expected none, trace, debug, info, warn, error, or fatal.", value));
+        throw runtime_error(_("invalid log level '{1}': expected none, trace, debug, info, warn, error, or fatal.", value));
     }
 
     ostream& operator<<(ostream& strm, log_level level)

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -2,10 +2,14 @@
 #include <leatherman/util/environment.hpp>
 #include <leatherman/execution/execution.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <sstream>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 using namespace std;
 using namespace leatherman::util;
@@ -128,7 +132,7 @@ namespace leatherman { namespace ruby {
     {
         lth_lib::dynamic_library library = find_library();
         if (!library.loaded()) {
-            throw library_not_loaded_exception("could not locate a ruby library");
+            throw library_not_loaded_exception(_("could not locate a ruby library"));
         } else if (library.first_load()) {
             LOG_INFO("ruby loaded from \"{1}\".", library.name());
         } else {
@@ -245,7 +249,7 @@ namespace leatherman { namespace ruby {
     {
         auto size = rb_num2ull(v);
         if (size > numeric_limits<size_t>::max()) {
-            throw invalid_conversion("size_t maximum exceeded, requested size was " + to_string(size));
+            throw invalid_conversion(_("size_t maximum exceeded, requested size was {1}", to_string(size)));
         }
         return static_cast<size_t>(size);
     }
@@ -426,7 +430,7 @@ namespace leatherman { namespace ruby {
         // encounter long values here.
         auto size = rb_num2ull(rb_funcall(array, rb_intern("size"), 0));
         if (size > numeric_limits<long>::max()) {
-            throw invalid_conversion("maximum array size exceeded, reported size was " + to_string(size));
+            throw invalid_conversion(_("maximum array size exceeded, reported size was {1}", to_string(size)));
         }
         return static_cast<long>(size);
     }

--- a/windows/src/file_util.cc
+++ b/windows/src/file_util.cc
@@ -6,9 +6,11 @@
 
 #include <shlobj.h>
 
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
 using namespace std;
 using namespace boost::filesystem;
-namespace lth_locale = leatherman::locale;
 
 namespace leatherman { namespace windows { namespace file_util {
 
@@ -18,7 +20,7 @@ namespace leatherman { namespace windows { namespace file_util {
             auto p = path(pdir);
             return p.string();
         }
-        throw unknown_folder_exception(lth_locale::format("error finding FOLDERID_ProgramData: {1}",
+        throw unknown_folder_exception(_("error finding FOLDERID_ProgramData: {1}",
                     leatherman::windows::system_error()));
     }
 

--- a/windows/src/registry.cc
+++ b/windows/src/registry.cc
@@ -5,8 +5,10 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/nowide/convert.hpp>
 
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
 using namespace std;
-namespace lth_locale = leatherman::locale;
 
 namespace leatherman { namespace windows {
 
@@ -27,7 +29,7 @@ namespace leatherman { namespace windows {
             case registry::HKEY::PERFORMANCE_TEXT:    return HKEY_PERFORMANCE_TEXT;
             case registry::HKEY::USERS:               return HKEY_USERS;
             default:
-                throw registry_exception("invalid HKEY specified");
+                throw registry_exception(_("invalid HKEY specified"));
         }
     }
 
@@ -42,7 +44,7 @@ namespace leatherman { namespace windows {
         DWORD size = 0u;
         auto err = RegGetValueW(hk, lpSubKeyW.c_str(), lpValueW.c_str(), flags, nullptr, nullptr, &size);
         if (err != ERROR_SUCCESS) {
-            throw registry_exception(lth_locale::format("error reading registry key {1} {2}: {3}",
+            throw registry_exception(_("error reading registry key {1} {2}: {3}",
                 lpSubKey, lpValue, windows::system_error(err)));
         }
 
@@ -50,7 +52,7 @@ namespace leatherman { namespace windows {
         wstring buffer((size*sizeof(char))/sizeof(wchar_t), '\0');
         err = RegGetValueW(hk, lpSubKeyW.c_str(), lpValueW.c_str(), flags, nullptr, &buffer[0], &size);
         if (err != ERROR_SUCCESS) {
-            throw registry_exception(lth_locale::format("error reading registry key {1} {2}: {3}",
+            throw registry_exception(_("error reading registry key {1} {2}: {3}",
                 lpSubKey, lpValue, windows::system_error(err)));
         }
 

--- a/windows/src/system_error.cc
+++ b/windows/src/system_error.cc
@@ -4,8 +4,10 @@
 #include <leatherman/locale/locale.hpp>
 #include <boost/nowide/convert.hpp>
 
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
 using namespace std;
-namespace lth_locale = leatherman::locale;
 
 namespace leatherman { namespace windows {
 
@@ -15,12 +17,12 @@ namespace leatherman { namespace windows {
         if (FormatMessageW(
             FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
             nullptr, err, 0, reinterpret_cast<LPWSTR>(&buffer), 0, nullptr) == 0 || !buffer) {
-            return lth_locale::format("unknown error ({1})", err);
+            return _("unknown error ({1})", err);
         }
 
         // boost format could throw, so ensure the buffer is freed.
         util::scoped_resource<LPWSTR> guard(buffer, [](LPWSTR ptr) { if (ptr) LocalFree(ptr); });
-        return lth_locale::format("{1} ({2})", boost::nowide::narrow(buffer), err);
+        return _("{1} ({2})", boost::nowide::narrow(buffer), err);
     }
 
     string system_error()

--- a/windows/src/wmi.cc
+++ b/windows/src/wmi.cc
@@ -1,18 +1,20 @@
 #include <leatherman/util/strings.hpp>
 #include <leatherman/windows/wmi.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/nowide/convert.hpp>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
 
 #define _WIN32_DCOM
 #include <comdef.h>
 #include <wbemidl.h>
 
 using namespace std;
-namespace lth_locale = leatherman::locale;
-#define _ lth_locale::translate
 
 namespace leatherman { namespace windows {
 
@@ -25,9 +27,9 @@ namespace leatherman { namespace windows {
     {
 #ifdef LEATHERMAN_I18N
         // LOCALE: format a pointer as hex for printing an error message.
-        return lth_locale::format("{1} (0x{2,num=hex})", s, hres);
+        return _("{1} (0x{2,num=hex})", s, hres);
 #else
-        return lth_locale::format("%1% (0x%2$#x)", s, hres);
+        return _("%1% (0x%2$#x)", s, hres);
 #endif
     }
 


### PR DESCRIPTION
This update marks a variety of exception and error messages for
translation and updates the leatherman.pot file. All logging
messages appear to be properly marked already.