### PR TITLE
(LTH-113) Fix building Leatherman without cflags

### DIFF
--- a/locale/inc/leatherman/locale/locale.hpp
+++ b/locale/inc/leatherman/locale/locale.hpp
@@ -24,6 +24,8 @@
 // Unset PROJECT_NAME so we only create a single locale.
 #undef PROJECT_NAME
 #define PROJECT_NAME ""
+#undef PROJECT_DIR
+#define PROJECT_DIR
 #endif
 
 namespace leatherman { namespace locale {


### PR DESCRIPTION
The cflags CMake module includes useful settings, but shouldn't be
required to build against Leatherman. Fix compilation so that's true.