### PR TITLE
(PCP-556) Logging backend doesn't consume records with lvl==none

### DIFF
--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -52,6 +52,11 @@ namespace leatherman { namespace logging {
     void color_writer::consume(boost::log::record_view const& rec)
     {
         auto level = boost::log::extract<log_level>("Severity", rec);
+
+        if (!is_enabled(*level)) {
+            return;
+        }
+
         auto line_num = boost::log::extract<int>("LineNum", rec);
         auto name_space = boost::log::extract<string>("Namespace", rec);
         auto timestamp = boost::log::extract<boost::posix_time::ptime>("TimeStamp", rec);


### PR DESCRIPTION
The Logging logger (logging::helper) is currently in charge of checking
the severity (compared to the configured log level) before creating a new
boost.log record. The sink backend (logging::color_writer) does
not check that when it consumes a record (color_writer::consume). Such
behaviour does not cope well with records created by severity loggers
other than the Logging logger, as the severity value gets ignored.

With this commit we deal with the case where a record created with a
third party severity logger has severity equals to 'none'; in such
case, the record will be discarded.