### PR TITLE
(LTH-115) Fix Boost.Log sink initialization with Boost 1.62

### DIFF
--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -82,7 +82,7 @@ namespace leatherman { namespace logging {
         core->remove_all_sinks();
 
         using sink_t = sinks::synchronous_sink<color_writer>;
-        boost::shared_ptr<sink_t> sink(new sink_t(&dst));
+        boost::shared_ptr<sink_t> sink = boost::make_shared<sink_t>(boost::make_shared<color_writer>(&dst));
         core->add_sink(sink);
 
 


### PR DESCRIPTION
In Boost 1.62, the way sink argument forwarding appears to have changed
in such a way that it failed to identify the implicit creation of a
color_writer. Switch to explicitly creating the color_writer sink.