### PR TITLE
(packaging) Prepare for 0.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.2]
+
+### Changed
+- leatherman::execution can now be requested to convert Windows line endings to standard ones (LTH-114)
+
 ## [0.9.1]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.9.1)
+project(leatherman VERSION 0.9.2)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.9.1\n"
+"Project-Id-Version: leatherman 0.9.2\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
The changes to leatherman::execution are needed for [FACT-1356](https://tickets.puppetlabs.com/browse/FACT-1356), which is scheduled to be released as part of Facter 3.5.0 (which in turn will go out in Puppet Agent 1.8.0). So we need to tag a new version of Leatherman.