### PR TITLE
(LTH-117) Switch to compile-time unpacking vendored packages

### DIFF
--- a/catch/CMakeLists.txt
+++ b/catch/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_leatherman_vendored("catch-1.4.0.zip" "71b8d1b08ff8da54928521742ffaf448" "include")
+add_leatherman_vendored("catch-1.4.0.zip" "catch" "include")

--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -5,7 +5,6 @@
 # interface.
 
 include(leatherman) # contains some helpers we use
-include(ExternalProject)
 
 ####
 # Macros for use by leatherman libraries

--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -343,20 +343,18 @@ function(append_new varname)
     set(${varname} ${${varname}} PARENT_SCOPE)
 endfunction()
 
-# Usage: unpack_vendored("pkg.zip" "abcdef..." SOURCE_DIR)
+# Usage: unpack_vendored("pkg.zip" "pkg" SOURCE_DIR)
 #
-# Unpacks a compressed package in the vendor directory and saves
-# the unpacked location to a variable.
-macro(unpack_vendored pkg md5 dir)
-    externalproject_add(
-        ${pkg}
-        PREFIX "${PROJECT_BINARY_DIR}"
-        URL "file://${PROJECT_SOURCE_DIR}/vendor/${pkg}"
-        URL_MD5 "${md5}"
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        BUILD_IN_SOURCE 1
-        INSTALL_COMMAND "")
-    externalproject_get_property(${pkg} SOURCE_DIR)
-    set(${dir} ${SOURCE_DIR})
+# Unpacks a compressed pkg.zip in the vendor directory to
+# ${PROJECT_BINARY_DIR}/src/pkg and saves the unpacked location to a variable.
+macro(unpack_vendored pkg extracted_dir dir)
+    set(pkgfile ${PROJECT_SOURCE_DIR}/vendor/${pkg})
+    set(${dir} ${PROJECT_BINARY_DIR}/src/${extracted_dir})
+
+    message(STATUS "Unpacking ${pkgfile} into ${${dir}}")
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/src)
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_SOURCE_DIR}/vendor/${pkg}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src
+        )
 endmacro(unpack_vendored)

--- a/rapidjson/CMakeLists.txt
+++ b/rapidjson/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_leatherman_vendored("rapidjson-1.0.2.zip" "fcb0beba59fc4e1e118a57413503e474" "include")
+add_leatherman_vendored("rapidjson-1.0.2.zip" "rapidjson" "include")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 include_directories(BEFORE ${LEATHERMAN_CATCH_INCLUDE} ${LEATHERMAN_INCLUDE_DIRS})
 add_executable(leatherman_test main.cc ${LEATHERMAN_TEST_SRCS})
-add_dependencies(leatherman_test catch)
 
 if (LEATHERMAN_SHARED)
     # Include deps first, as they may be static. If they are, linking on Windows can


### PR DESCRIPTION
CMake doesn't handle include file dependencies with ExternalProject_Add.
Switch to unpacking files at compile-time so they can be used in
dependency resolution.
