### PR TITLE
(LTH-118) Remove Leatherman removing the lib prefix off targets 

### DIFF
--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -69,20 +69,11 @@ endmacro()
 # On Windows shared libraries go in bin, import and archive libraries
 # go in lib. On Linux shared libraries go in lib. Binaries go in bin.
 #
-# Also always drop the prefix; give the target its expected name.
-# We often have binaries and related dynamic libraries, and this
-# simplifies giving them different but related names, such as
-# `facter` and `libfacter`.
 macro(leatherman_install)
     install(TARGETS ${ARGV}
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib${LIB_SUFFIX}
         ARCHIVE DESTINATION lib${LIB_SUFFIX})
-    foreach(ARG ${ARGV})
-        if (TARGET ${ARG})
-            set_target_properties(${ARG} PROPERTIES PREFIX "" IMPORT_PREFIX "")
-        endif()
-    endforeach()
 endmacro()
 
 # Usage: add_cppcheck_dirs(dir1 dir2)


### PR DESCRIPTION
it installs.  This makes it generate libraries in expected places on unix line OSs.  NOTE:  This has downstream project implications that need managed - I am working on CPP-HOCON and a patch for that should be forthcoming
