### PR TITLE
(maint) explicitly pass release flag to pod2man

### DIFF
--- a/cmake/pod2man.cmake
+++ b/cmake/pod2man.cmake
@@ -21,7 +21,7 @@ macro(pod2man PODFILE MANFILE SECTION OUTPATH CENTER)
         add_custom_command(
             OUTPUT ${OUTPATH_NEW}/${MANFILE}.${SECTION}
             COMMAND ${POD2MAN} --section ${SECTION} --center ${CENTER}
-                --release --name ${MANFILE} ${PODFILE}
+                --release "\"\"" --name ${MANFILE} ${PODFILE}
                 ${OUTPATH_NEW}/${MANFILE}.${SECTION}
         )
         set(MANPAGE_TARGET "man-${MANFILE}")


### PR DESCRIPTION
This is a followup on
https://github.com/puppetlabs/orchestrator-client/pull/270

This flag is required when using podman >= 4 or perl 5.24, although I
don't think it has any consequence in leatherman right now since there
are no man pages.