### PR TITLE
(LTH-120) Generalized detached process

### DIFF
--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -42,7 +42,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
     # missing-field-initializers is disabled because GCC can't make up their mind how to treat C++11 initializers
     set(LEATHERMAN_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-unknown-pragmas -Wno-missing-field-initializers")
-    if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+    if ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+        # this is needed to link against the libcontract library
+        EXECUTE_PROCESS( COMMAND getconf LFS_CFLAGS OUTPUT_VARIABLE LFS_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE )
+        set(LEATHERMAN_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} ${LFS_CFLAGS}")
+    else()
         set(LEATHERMAN_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} -Wextra")
     endif()
 

--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -1,6 +1,12 @@
 find_package(Boost 1.54 REQUIRED COMPONENTS regex filesystem system)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+    # We use functions provided by this library in the implementation
+    # of the create_detached_process execution option on Solaris to
+    # execute the child processes in their own contracts
+    add_leatherman_deps(contract)
+endif()
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")
 
 leatherman_dependency(util)
@@ -21,13 +27,20 @@ add_leatherman_headers(inc/leatherman)
 if(WIN32)
     add_leatherman_library(src/execution.cc src/windows/execution.cc)
 else()
-    add_leatherman_library(src/execution.cc src/posix/execution.cc)
+    if("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+        add_leatherman_library(src/execution.cc src/posix/execution.cc src/posix/solaris/platform.cc)
+    else()
+        add_leatherman_library(src/execution.cc src/posix/execution.cc src/posix/generic/platform.cc)
+    endif()
 endif()
 
 if(WIN32)
     set(PLATFORM_TESTS tests/windows/execution.cc)
 else()
     set(PLATFORM_TESTS tests/posix/execution.cc)
+    if("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+        list(APPEND PLATFORM_TESTS tests/posix/solaris/execution.cc)
+    endif()
 endif()
 
 add_leatherman_test(tests/log_capture.cc ${PLATFORM_TESTS})

--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -57,9 +57,10 @@ namespace leatherman { namespace execution {
          */
         preserve_arguments = (1 << 7),
         /**
-         * On Windows, create a new process group for the child process, but not a Job Object.
+         * Create a new process such that it can outlive its parent. This involves running it
+         * in a separate process group on Windows, and in a separate contract on Solaris.
          */
-        create_new_process_group = (1 << 8),
+        create_detached_process = (1 << 8),
         /**
          * Inherit locale environment variables from the current process. Limited to LC_ALL and
          * LOCALE, which are specifically overridden to "C" with merge_environment.

--- a/execution/src/posix/generic/platform.cc
+++ b/execution/src/posix/generic/platform.cc
@@ -1,0 +1,27 @@
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/locale/locale.hpp>
+#include "../platform.hpp"
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
+namespace leatherman { namespace execution {
+
+    pid_t create_child(bool detach, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    {
+        // Fork the child process
+        // Note: this uses vfork, which is inherently unsafe (the parent's address space is shared with the child)
+        pid_t pid = vfork();
+        if (pid < 0) {
+            throw execution_exception(format_error(_("failed to fork child process")));
+        }
+
+        if (pid == 0) {  // Is this the child process?
+            // Exec the child; this never returns
+            exec_child(in_fd, out_fd, err_fd, program, argv, envp);
+        }
+
+        return pid;
+    }
+
+}}  // namespace leatherman::execution

--- a/execution/src/posix/platform.hpp
+++ b/execution/src/posix/platform.hpp
@@ -1,0 +1,12 @@
+#include <unistd.h>
+#include <errno.h>
+
+namespace leatherman { namespace execution {
+
+    std::string format_error(std::string const& message = std::string(), int error = errno);
+
+    pid_t create_child(bool detach, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp);
+
+    void exec_child(int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp);
+
+}}  // namespace leatherman::execution

--- a/execution/src/posix/solaris/platform.cc
+++ b/execution/src/posix/solaris/platform.cc
@@ -1,0 +1,197 @@
+/*
+ * Portions of this file were copied from OpenSSH's
+ * openbsd-compat/port-solaris.c file, that file
+ * contained the following copyright notice:
+ *
+ * Copyright (c) 2006 Chad Mynhier.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/locale/locale.hpp>
+#include <boost/format.hpp>
+
+#include <fcntl.h>
+#include <libcontract.h>
+#include <sys/ctfs.h>
+#include <sys/contract/process.h>
+
+#include "../platform.hpp"
+
+#define CT_TEMPLATE CTFS_ROOT "/process/template"
+#define CT_LATEST CTFS_ROOT "/process/latest"
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
+using namespace std;
+
+namespace leatherman { namespace execution {
+
+    static int activate_new_contract_template(void)
+    {
+        int tmpl_fd;
+        int err;
+
+        // Open a template
+        if ((tmpl_fd = open64(CT_TEMPLATE, O_RDWR)) == -1) {
+            err = errno;
+            goto fail;
+        }
+
+        // Set the template parameters and event sets
+        if ((err = ct_pr_tmpl_set_param(tmpl_fd, CT_PR_PGRPONLY)) != 0) {
+            goto close_fail;
+        }
+        if ((err = ct_pr_tmpl_set_fatal(tmpl_fd, CT_PR_EV_HWERR)) != 0) {
+            goto close_fail;
+        }
+        if ((err = ct_tmpl_set_critical(tmpl_fd, 0)) != 0) {
+            goto close_fail;
+        }
+        if ((err = ct_tmpl_set_informative(tmpl_fd, CT_PR_EV_HWERR)) != 0) {
+            goto close_fail;
+        }
+
+        // Now make this the active template for this process
+        if ((err = ct_tmpl_activate(tmpl_fd)) != 0) {
+            goto close_fail;
+        }
+
+        return tmpl_fd;
+
+    close_fail:
+        close(tmpl_fd);
+    fail:
+        throw execution_exception(format_error(_("failed to create process contract template"), err));
+    }
+
+    static int deactivate_contract_template(int tmpl_fd)
+    {
+        // WARNING: this function is called from a vfork'd child
+        // Do not modify program state from this function; only call setpgid, dup2, close, execve, and _exit
+        // Do not allocate heap memory or throw exceptions
+        // The child is sharing the address space of the parent process, so carelessly modifying this
+        // function may lead to parent state corruption, memory leaks, and/or total protonic reversal
+
+        if (tmpl_fd < 0) {
+            return 0;
+        }
+
+        // Deactivate the template
+        int err = ct_tmpl_clear(tmpl_fd);
+
+        close(tmpl_fd);
+
+        return err;
+    }
+
+    // Lookup the latest child process contract ID
+    static ctid_t get_latest_child_contract_id(void)
+    {
+        int stat_fd;
+        ct_stathdl_t stathdl;
+        ctid_t ctid;
+        int err;
+
+        if ((stat_fd = open64(CT_LATEST, O_RDONLY)) < 0) {
+            err = errno;
+            goto fail;
+        }
+
+        if ((err = ct_status_read(stat_fd, CTD_COMMON, &stathdl)) != 0) {
+            close(stat_fd);
+            goto fail;
+        }
+
+        ctid = ct_status_get_id(stathdl);
+        err = errno;
+
+        ct_status_free(stathdl);
+        close(stat_fd);
+
+        if (ctid < 0) {
+            goto fail;
+        }
+
+        return ctid;
+
+    fail:
+        throw execution_exception(format_error(_("failed to lookup the latest child process contract"), err));
+    }
+
+    static void abandon_latest_child_contract()
+    {
+        ctid_t ctid = get_latest_child_contract_id();
+        int ctl_fd;
+        int err;
+
+        if ((ctl_fd = open64((boost::format { "%s/process/%d/ctl" } % CTFS_ROOT % ctid).str().c_str(), O_WRONLY)) < 0) {
+            err = errno;
+            goto fail;
+        }
+
+        // Abandon the contract created for the child process
+        err = ct_ctl_abandon(ctl_fd);
+
+        close(ctl_fd);
+
+        if (err == 0) {
+            return;
+        }
+
+    fail:
+        throw execution_exception(format_error(_("failed to abandon contract created for a child process"), err));
+    }
+
+    pid_t create_child(bool detach, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    {
+        // Create a new process contract template & activate it
+        int tmpl_fd = detach ? activate_new_contract_template() : -1;
+        int err;
+
+        // Fork the child process
+        // Note: this uses vfork, which is inherently unsafe (the parent's address space is shared with the child)
+        pid_t pid = vfork();
+        if (pid < 0) {
+            err = errno;
+            deactivate_contract_template(tmpl_fd);
+            throw execution_exception(format_error(_("failed to fork child process"), err));
+        }
+
+        if (pid == 0) {  // Is this the child process?
+            if ((err = deactivate_contract_template(tmpl_fd)) != 0) {
+                string message = format_error(_("failed to deactivate contract template in the child process"), err);
+                if (write(err_fd, message.c_str(), message.size()) == -1) {
+                    // Do not care
+                }
+                _exit(err);
+            }
+            // Exec the child; this never returns
+            exec_child(in_fd, out_fd, err_fd, program, argv, envp);
+        }
+
+        // This is the parent process
+        if ((err = deactivate_contract_template(tmpl_fd)) != 0) {
+            throw execution_exception(format_error(_("failed to deactivate contract template created for a child process"), err));
+        }
+        if (detach) {
+            // Abandon the contract created for the child process
+            abandon_latest_child_contract();
+        }
+
+        return pid;
+    }
+
+}}  // namespace leatherman::execution

--- a/execution/src/windows/execution.cc
+++ b/execution/src/windows/execution.cc
@@ -564,14 +564,14 @@ namespace leatherman { namespace execution {
 
         PROCESS_INFORMATION procInfo = {};
 
-        // Set up flags for CreateProcess based on whether the create_new_process_group
+        // Set up flags for CreateProcess based on whether the create_detached_process
         // option was set and the parent process is running in a Job object.
         auto creation_flags = CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT;
 
         if (use_job_object) {
             creation_flags |= CREATE_BREAKAWAY_FROM_JOB;
         }
-        if (options[execution_options::create_new_process_group]) {
+        if (options[execution_options::create_detached_process]) {
             creation_flags |= CREATE_NEW_PROCESS_GROUP;
         }
 
@@ -603,7 +603,7 @@ namespace leatherman { namespace execution {
 
         // Use a Job Object to group any child processes spawned by the CreateProcess invocation, so we can
         // easily stop them in case of a timeout.
-        bool create_job_object = use_job_object && !options[execution_options::create_new_process_group];
+        bool create_job_object = use_job_object && !options[execution_options::create_detached_process];
         scoped_handle hJob;
         if (create_job_object) {
             hJob = scoped_handle(CreateJobObjectW(nullptr, nullptr));

--- a/execution/tests/posix/solaris/execution.cc
+++ b/execution/tests/posix/solaris/execution.cc
@@ -1,0 +1,54 @@
+#include <catch.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/util/strings.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+using namespace std;
+using namespace leatherman::execution;
+
+SCENARIO("executing detached commands with execution::execute") {
+    auto get_ctids = [](string const& input) {
+        vector<int> ctids;
+        leatherman::util::each_line(input, [&ctids](string& line) {
+            try {
+                boost::algorithm::trim(line);
+                ctids.push_back(boost::lexical_cast<int>(line));
+            } catch(boost::bad_lexical_cast const&) {
+                ctids.clear();
+                return false;
+            }
+            return true;
+        });
+        return ctids;
+    };
+    GIVEN("the detached process creation is requested") {
+        THEN("the command is executed in a different process contract than its parent") {
+            auto exec = execute("/bin/sh", { "-c", "ps -o ctid= -p $EXECUTOR_PID,$$" },
+                                { { "EXECUTOR_PID", to_string(getpid()) } },
+                                0,
+                                { execution_options::create_detached_process,
+                                  execution_options::merge_environment,
+                                  execution_options::redirect_stderr_to_null });
+            REQUIRE(exec.success);
+            REQUIRE(exec.exit_code == 0);
+            auto ctids = get_ctids(exec.output);
+            REQUIRE(ctids.size() == 2); // the ps command returned two CTIDs
+            REQUIRE(ctids[0] != ctids[1]); // the contract IDs are different
+        }
+    }
+    GIVEN("the detached process creation is NOT requested") {
+        THEN("the command is executed in the same process contract as its parent") {
+            auto exec = execute("/bin/sh", { "-c", "ps -o ctid= -p $EXECUTOR_PID,$$" },
+                                { { "EXECUTOR_PID", to_string(getpid()) } },
+                                0,
+                                { execution_options::merge_environment,
+                                  execution_options::redirect_stderr_to_null });
+            REQUIRE(exec.success);
+            REQUIRE(exec.exit_code == 0);
+            auto ctids = get_ctids(exec.output);
+            REQUIRE(ctids.size() == 2); // the ps command returned two CTIDs
+            REQUIRE(ctids[0] == ctids[1]); // the contract IDs are the same
+        }
+    }
+}

--- a/execution/tests/windows/execution.cc
+++ b/execution/tests/windows/execution.cc
@@ -126,7 +126,7 @@ SCENARIO("executing commands with execution::execute") {
             REQUIRE(exec.exit_code == 0);
         }
         WHEN("the create new process group option is used") {
-            auto exec = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file3.txt") }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null, execution_options::create_new_process_group });
+            auto exec = execute("cmd.exe", { "/c", "type", normalize(EXEC_TESTS_DIRECTORY "/fixtures/ls/file3.txt") }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null, execution_options::create_detached_process });
             REQUIRE(exec.success);
             REQUIRE(exec.output == "file3");
             REQUIRE(exec.error == "");
@@ -229,7 +229,7 @@ SCENARIO("executing commands with execution::execute") {
             }
         }
         WHEN("the create new process group option is used") {
-            auto exec = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null, execution_options::create_new_process_group });
+            auto exec = execute("cmd.exe", { "/c", "dir", "/B", "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null, execution_options::create_detached_process });
             THEN("no output is returned") {
                 REQUIRE_FALSE(exec.success);
                 REQUIRE(exec.output == "");

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -185,10 +185,6 @@ msgstr ""
 msgid "{1}={2}"
 msgstr ""
 
-#: execution/src/posix/execution.cc
-msgid "failed to fork child process"
-msgstr ""
-
 #. debug
 #: execution/src/posix/execution.cc
 #: execution/src/windows/execution.cc
@@ -244,6 +240,31 @@ msgstr ""
 
 #: execution/src/posix/execution.cc
 msgid "child process was terminated by signal ({1})."
+msgstr ""
+
+#: execution/src/posix/generic/platform.cc
+#: execution/src/posix/solaris/platform.cc
+msgid "failed to fork child process"
+msgstr ""
+
+#: execution/src/posix/solaris/platform.cc
+msgid "failed to create process contract template"
+msgstr ""
+
+#: execution/src/posix/solaris/platform.cc
+msgid "failed to lookup the latest child process contract"
+msgstr ""
+
+#: execution/src/posix/solaris/platform.cc
+msgid "failed to abandon contract created for a child process"
+msgstr ""
+
+#: execution/src/posix/solaris/platform.cc
+msgid "failed to deactivate contract template in the child process"
+msgstr ""
+
+#: execution/src/posix/solaris/platform.cc
+msgid "failed to deactivate contract template created for a child process"
 msgstr ""
 
 #: execution/src/windows/execution.cc


### PR DESCRIPTION
This PR renames the `create_new_process_group` execution option to `create_detached_process`.
The intention of the option was to create a process in such a way it is detached from its parent in terms of their lifespan. On Windows, which was the only platform where the option was implemented, the child process would be killed when the parent process exited in case the option was not specified. On the contrary the child can outlive its parent when the option is specified.
The renaming of the option is a preparation for generalization of the concept to other OSs where it is also applicable (notably Solaris) but where the original name would not make sense or would be misleading.
The other commit in this PR provides the Solaris implementation of the option which mainly entails creating separate process contracts for the child processes.