### PR TITLE
(LTH-116) Handle null characters in JSON strings

### DIFF
--- a/json_container/src/json_container.cc
+++ b/json_container/src/json_container.cc
@@ -181,7 +181,7 @@ namespace leatherman { namespace json_container {
         if (jval->IsObject()) {
             for (json_value::ConstMemberIterator itr = jval->MemberBegin();
                  itr != jval->MemberEnd(); ++itr) {
-                k.push_back(itr->name.GetString());
+                k.emplace_back(itr->name.GetString(), itr->name.GetStringLength());
             }
         }
 
@@ -387,7 +387,7 @@ namespace leatherman { namespace json_container {
             throw data_type_error { "not a string" };
         }
 
-        return std::string(value.GetString());
+        return std::string(value.GetString(), value.GetStringLength());
     }
 
     template<>
@@ -443,7 +443,7 @@ namespace leatherman { namespace json_container {
                 throw data_type_error { "not a string" };
             }
 
-            tmp.push_back(itr->GetString());
+            tmp.emplace_back(itr->GetString(), itr->GetStringLength());
         }
 
         return tmp;


### PR DESCRIPTION
Before this patch leatherman could not handle null characters (`\u0000`)
in JSON keys/values because it used the single argument `std::string`
constructor to create `std::string` representations of those keys/values.
The problem was that the null character is treated as the end of the
string by that constructor, so any key/value containing the null character
was truncated at that character when represented as the `std::string`.
The fix is to use the two argument constructor of `std::string` where the
second argument specifies the length of the value to store in the string.
The respective length is readily obtainable from the JSON parsing library.