### PR TITLE
(LTH-120) Isolate lfs to Leatherman.execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.10.1]
+
+### Fixed
+- Only apply large file support flags to Leatherman.execution (LTH-120)
+
 ## [0.10.0]
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.10.0)
+project(leatherman VERSION 0.10.1)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)

--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -42,11 +42,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
     # missing-field-initializers is disabled because GCC can't make up their mind how to treat C++11 initializers
     set(LEATHERMAN_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-unknown-pragmas -Wno-missing-field-initializers")
-    if ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
-        # this is needed to link against the libcontract library
-        EXECUTE_PROCESS( COMMAND getconf LFS_CFLAGS OUTPUT_VARIABLE LFS_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE )
-        set(LEATHERMAN_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} ${LFS_CFLAGS}")
-    else()
+    if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
         set(LEATHERMAN_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} -Wextra")
     endif()
 

--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -28,6 +28,12 @@ if(WIN32)
     add_leatherman_library(src/execution.cc src/windows/execution.cc)
 else()
     if("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+        # LFS flags are needed to compile the posix/solaris/platform.cc such that it links correctly
+        # against the libcontract library. They're not applied universally as they impact the ability
+        # to use other OS functions. This usage is safe as long as global variables based on these flags
+        # are avoided, according to http://docs.oracle.com/cd/E19455-01/806-0634/6j9vo5alu/index.html
+        EXECUTE_PROCESS( COMMAND getconf LFS_CFLAGS OUTPUT_VARIABLE LFS_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE )
+        set(LEATHERMAN_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS} ${LFS_CFLAGS}")
         add_leatherman_library(src/execution.cc src/posix/execution.cc src/posix/solaris/platform.cc)
     else()
         add_leatherman_library(src/execution.cc src/posix/execution.cc src/posix/generic/platform.cc)

--- a/execution/src/posix/solaris/platform.cc
+++ b/execution/src/posix/solaris/platform.cc
@@ -45,7 +45,7 @@ namespace leatherman { namespace execution {
         int err;
 
         // Open a template
-        if ((tmpl_fd = open64(CT_TEMPLATE, O_RDWR)) == -1) {
+        if ((tmpl_fd = open(CT_TEMPLATE, O_RDWR)) == -1) {
             err = errno;
             goto fail;
         }
@@ -105,7 +105,7 @@ namespace leatherman { namespace execution {
         ctid_t ctid;
         int err;
 
-        if ((stat_fd = open64(CT_LATEST, O_RDONLY)) < 0) {
+        if ((stat_fd = open(CT_LATEST, O_RDONLY)) < 0) {
             err = errno;
             goto fail;
         }
@@ -137,7 +137,7 @@ namespace leatherman { namespace execution {
         int ctl_fd;
         int err;
 
-        if ((ctl_fd = open64((boost::format { "%s/process/%d/ctl" } % CTFS_ROOT % ctid).str().c_str(), O_WRONLY)) < 0) {
+        if ((ctl_fd = open((boost::format { "%s/process/%d/ctl" } % CTFS_ROOT % ctid).str().c_str(), O_WRONLY)) < 0) {
             err = errno;
             goto fail;
         }

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.9.3\n"
+"Project-Id-Version: leatherman 0.10.1\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Solaris large file support is needed for the ctrun functionality in
Leatherman.execution. It's tricky to apply everywhere however, which
caused building Facter with this version of Leatherman to fail. Restrict
large file support flags to Leatherman.execution.

Only applying lfs to some files should be safe according to
http://docs.oracle.com/cd/E19455-01/806-0634/6j9vo5alu/index.html

```
Applications may combine objects produced in the large file compilation
environment with objects produced in the transitional compilation
environment, but must be careful with respect to interoperability
between those objects. Applications should not declare global variables
of types whose sizes change between compilation environments.
```