### PR TITLE
(maint) Avoid heap allocations during exec

### DIFF
--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -281,11 +281,17 @@ namespace leatherman { namespace execution {
         // Do not allocate heap memory or throw exceptions
         // The child is sharing the address space of the parent process, so carelessly modifying this
         // function may lead to parent state corruption, memory leaks, and/or total protonic reversal
+        // As such, strings are explicitly not localized in this function.
+        //
+        // This is especially important due to a deadlock in vfork/exec on Solaris, identified in
+        // http://www.oracle.com/technetwork/server-storage/solaris10/subprocess-136439.html. The solution
+        // they use in posix_spawn is to avoid calling functions exported as from libc as global symbols
+        // after the fork. `write`, `strlen`, and `close` are still suspect below.
 
         // Set the process group; this will be used by the parent if we need to kill the process and its children
         if (setpgid(0, 0) == -1) {
-            string message = _("failed to setpgid.");
-            if (write(err_fd, message.c_str(), message.size()) == -1) {
+            char const* message = "failed to setpgid.";
+            if (write(err_fd, message, strlen(message)) == -1) {
                 // Do not care
             }
             return;
@@ -293,8 +299,8 @@ namespace leatherman { namespace execution {
 
         // Redirect stdin
         if (dup2(in_fd, STDIN_FILENO) == -1) {
-            string message = _("failed to redirect child stdin.");
-            if (write(err_fd, message.c_str(), message.size()) == -1) {
+            char const* message = "failed to redirect child stdin.";
+            if (write(err_fd, message, strlen(message)) == -1) {
                 // Do not care
             }
             return;
@@ -302,8 +308,8 @@ namespace leatherman { namespace execution {
 
         // Redirect stdout
         if (dup2(out_fd, STDOUT_FILENO) == -1) {
-            string message = _("failed to redirect child stdout.");
-            if (write(err_fd, message.c_str(), message.size()) == -1) {
+            char const* message = "failed to redirect child stdout.";
+            if (write(err_fd, message, strlen(message)) == -1) {
                 // Do not care
             }
             return;
@@ -311,8 +317,8 @@ namespace leatherman { namespace execution {
 
         // Redirect stderr
         if (dup2(err_fd, STDERR_FILENO) == -1) {
-            string message = _("failed to redirect child stderr.");
-            if (write(err_fd, message.c_str(), message.size()) == -1) {
+            char const* message = "failed to redirect child stderr.";
+            if (write(err_fd, message, strlen(message)) == -1) {
                 // Do not care
             }
             return;

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -290,43 +290,22 @@ namespace leatherman { namespace execution {
 
         // Set the process group; this will be used by the parent if we need to kill the process and its children
         if (setpgid(0, 0) == -1) {
-            char const* message = "failed to setpgid.";
-            if (write(err_fd, message, strlen(message)) == -1) {
-                // Do not care
-            }
             return;
         }
 
         // Redirect stdin
         if (dup2(in_fd, STDIN_FILENO) == -1) {
-            char const* message = "failed to redirect child stdin.";
-            if (write(err_fd, message, strlen(message)) == -1) {
-                // Do not care
-            }
             return;
         }
 
         // Redirect stdout
         if (dup2(out_fd, STDOUT_FILENO) == -1) {
-            char const* message = "failed to redirect child stdout.";
-            if (write(err_fd, message, strlen(message)) == -1) {
-                // Do not care
-            }
             return;
         }
 
         // Redirect stderr
         if (dup2(err_fd, STDERR_FILENO) == -1) {
-            char const* message = "failed to redirect child stderr.";
-            if (write(err_fd, message, strlen(message)) == -1) {
-                // Do not care
-            }
             return;
-        }
-
-        // Close all open file descriptors above stderr
-        for (decltype(get_max_descriptor_limit()) i = (STDERR_FILENO + 1); i < get_max_descriptor_limit(); ++i) {
-            close(i);
         }
 
         // Execute the given program; this should not return if successful

--- a/execution/src/posix/solaris/platform.cc
+++ b/execution/src/posix/solaris/platform.cc
@@ -172,8 +172,8 @@ namespace leatherman { namespace execution {
 
         if (pid == 0) {  // Is this the child process?
             if ((err = deactivate_contract_template(tmpl_fd)) != 0) {
-                string message = format_error(_("failed to deactivate contract template in the child process"), err);
-                if (write(err_fd, message.c_str(), message.size()) == -1) {
+                char const* message = "failed to deactivate contract template in the child process";
+                if (write(err_fd, message, strlen(message)) == -1) {
                     // Do not care
                 }
                 _exit(err);

--- a/execution/src/posix/solaris/platform.cc
+++ b/execution/src/posix/solaris/platform.cc
@@ -172,10 +172,6 @@ namespace leatherman { namespace execution {
 
         if (pid == 0) {  // Is this the child process?
             if ((err = deactivate_contract_template(tmpl_fd)) != 0) {
-                char const* message = "failed to deactivate contract template in the child process";
-                if (write(err_fd, message, strlen(message)) == -1) {
-                    // Do not care
-                }
                 _exit(err);
             }
             // Exec the child; this never returns

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -166,22 +166,6 @@ msgid "command timed out after {1} seconds."
 msgstr ""
 
 #: execution/src/posix/execution.cc
-msgid "failed to setpgid."
-msgstr ""
-
-#: execution/src/posix/execution.cc
-msgid "failed to redirect child stdin."
-msgstr ""
-
-#: execution/src/posix/execution.cc
-msgid "failed to redirect child stdout."
-msgstr ""
-
-#: execution/src/posix/execution.cc
-msgid "failed to redirect child stderr."
-msgstr ""
-
-#: execution/src/posix/execution.cc
 msgid "{1}={2}"
 msgstr ""
 
@@ -257,10 +241,6 @@ msgstr ""
 
 #: execution/src/posix/solaris/platform.cc
 msgid "failed to abandon contract created for a child process"
-msgstr ""
-
-#: execution/src/posix/solaris/platform.cc
-msgid "failed to deactivate contract template in the child process"
 msgstr ""
 
 #: execution/src/posix/solaris/platform.cc


### PR DESCRIPTION
Removes string localization in forked child exec, as heap allocation is
not safe there.