### PR TITLE
(LTH-126) Make it possible to use fork() on demand

### DIFF
--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS thread regex filesystem system)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex filesystem system)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")

--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -71,7 +71,16 @@ namespace leatherman { namespace execution {
          * On windows, converts \r\n newlines to standard \n
          */
         convert_newlines = (1 << 10),
-         /**
+        /**
+         * On POSIX systems, use `fork()` instead of `vfork()` when creating the new process.
+         * Ignored on windows.
+         * The `fork()` is typically slower than `vfork()` because it creates a copy
+         * of the parent's address space for the child process (`vfork()` lets the
+         * child process re-use the parent's address space) but safer from deadlocks
+         * if called from multi threaded processes.
+         */
+        thread_safe = (1 << 11),
+        /**
          * A combination of all throw options.
          */
         throw_on_failure = throw_on_nonzero_exit | throw_on_signal,

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -15,12 +15,6 @@
 #include <fcntl.h>
 #include <signal.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#include <boost/thread/thread.hpp>
-#include <boost/thread/locks.hpp>
-#pragma GCC diagnostic pop
-
 #include "platform.hpp"
 
 // Mark string for translation (alias for leatherman::locale::format)
@@ -280,7 +274,7 @@ namespace leatherman { namespace execution {
         throw timeout_exception(_("command timed out after {1} seconds.", timeout), static_cast<size_t>(child));
     }
 
-    static void do_exec_child(int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    static void do_exec_child(int in_fd, int out_fd, int err_fd, uint64_t max_fd, char const* program, char const** argv, char const** envp)
     {
         // WARNING: this function is potentially called from a vfork'd child
         // Do not modify program state from this function; only call setpgid, dup2, close, execve, and _exit
@@ -314,11 +308,16 @@ namespace leatherman { namespace execution {
             return;
         }
 
+        // Close all open file descriptors above stderr
+        for (uint64_t i = (STDERR_FILENO + 1); i < max_fd; ++i) {
+            close(i);
+        }
+
         // Execute the given program; this should not return if successful
         execve(program, const_cast<char* const*>(argv), const_cast<char* const*>(envp));
     }
 
-    void exec_child(int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    void exec_child(int in_fd, int out_fd, int err_fd, uint64_t max_fd, char const* program, char const** argv, char const** envp)
     {
         // WARNING: this function is potentially called from a vfork'd child
         // Do not modify program state from this function; only call setpgid, dup2, close, execve, and _exit
@@ -326,7 +325,7 @@ namespace leatherman { namespace execution {
         // The child is sharing the address space of the parent process, so carelessly modifying this
         // function may lead to parent state corruption, memory leaks, and/or total protonic reversal
 
-        do_exec_child(in_fd, out_fd, err_fd, program, argv, envp);
+        do_exec_child(in_fd, out_fd, err_fd, max_fd, program, argv, envp);
 
         // If we've reached here, we've failed, so exit the child
         _exit(errno == 0 ? EXIT_FAILURE : errno);
@@ -454,30 +453,11 @@ namespace leatherman { namespace execution {
                                             options[execution_options::inherit_locale]);
         auto envp = to_exec_arg(&variables);
 
-        // This section uses system operations in a way that is not thread-safe.
-        // Use a mutex to ensure we only execute it serially.
-        static boost::mutex exec_mutex;
-        pid_t child;
-        {
-            boost::lock_guard<boost::mutex> the_lock { exec_mutex };
-            // Set all open file descriptors above stderr to close on exec
-            auto max_desc_limit = get_max_descriptor_limit();
-            std::vector<int> fd_flags(max_desc_limit);
-            for (decltype(max_desc_limit) i = (STDERR_FILENO + 1); i < max_desc_limit; ++i) {
-                fd_flags[i] = fcntl(i, F_GETFD);
-                fcntl(i, F_SETFD, FD_CLOEXEC);
-            }
-
-            // Create the child
-            child = create_child(options,
-                                 stdin_read, stdout_write, child_stderr,
-                                 executable.c_str(), args.data(), envp.data());
-
-            // Reset flags on all open file descriptors above stderr
-            for (decltype(max_desc_limit) i = (STDERR_FILENO + 1); i < max_desc_limit; ++i) {
-                fcntl(i, F_SETFD, fd_flags[i]);
-            }
-        }
+        // Create the child
+        pid_t child = create_child(options,
+                                   stdin_read, stdout_write, child_stderr,
+                                   get_max_descriptor_limit(),
+                                   executable.c_str(), args.data(), envp.data());
 
         // Close the unused descriptors
         if (!input) {

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -46,7 +46,7 @@ namespace leatherman { namespace execution {
 
     static uint64_t get_max_descriptor_limit()
     {
-        // WARNING: this function is called under vfork
+        // WARNING: this function is potentially called under vfork
         // See comment below in exec_child in case you're not afraid
 #ifdef _SC_OPEN_MAX
         {
@@ -282,7 +282,7 @@ namespace leatherman { namespace execution {
 
     static void do_exec_child(int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
     {
-        // WARNING: this function is called from a vfork'd child
+        // WARNING: this function is potentially called from a vfork'd child
         // Do not modify program state from this function; only call setpgid, dup2, close, execve, and _exit
         // Do not allocate heap memory or throw exceptions
         // The child is sharing the address space of the parent process, so carelessly modifying this
@@ -320,7 +320,7 @@ namespace leatherman { namespace execution {
 
     void exec_child(int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
     {
-        // WARNING: this function is called from a vfork'd child
+        // WARNING: this function is potentially called from a vfork'd child
         // Do not modify program state from this function; only call setpgid, dup2, close, execve, and _exit
         // Do not allocate heap memory or throw exceptions
         // The child is sharing the address space of the parent process, so carelessly modifying this
@@ -469,7 +469,7 @@ namespace leatherman { namespace execution {
             }
 
             // Create the child
-            child = create_child(options[execution_options::create_detached_process],
+            child = create_child(options,
                                  stdin_read, stdout_write, child_stderr,
                                  executable.c_str(), args.data(), envp.data());
 

--- a/execution/src/posix/generic/platform.cc
+++ b/execution/src/posix/generic/platform.cc
@@ -7,11 +7,12 @@ using leatherman::locale::_;
 
 namespace leatherman { namespace execution {
 
-    pid_t create_child(bool detach, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    pid_t create_child(leatherman::util::option_set<execution_options> const& options, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
     {
         // Fork the child process
-        // Note: this uses vfork, which is inherently unsafe (the parent's address space is shared with the child)
-        pid_t pid = vfork();
+        // Note: this uses vfork (unless the thread_safe execution option is specified), which is inherently unsafe
+        // (the parent's address space is shared with the child)
+        pid_t pid = options[execution_options::thread_safe] ? fork() : vfork();
         if (pid < 0) {
             throw execution_exception(format_error(_("failed to fork child process")));
         }

--- a/execution/src/posix/generic/platform.cc
+++ b/execution/src/posix/generic/platform.cc
@@ -7,7 +7,9 @@ using leatherman::locale::_;
 
 namespace leatherman { namespace execution {
 
-    pid_t create_child(leatherman::util::option_set<execution_options> const& options, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    pid_t create_child(leatherman::util::option_set<execution_options> const& options,
+                       int in_fd, int out_fd, int err_fd, uint64_t max_fd,
+                       char const* program, char const** argv, char const** envp)
     {
         // Fork the child process
         // Note: this uses vfork (unless the thread_safe execution option is specified), which is inherently unsafe
@@ -19,7 +21,7 @@ namespace leatherman { namespace execution {
 
         if (pid == 0) {  // Is this the child process?
             // Exec the child; this never returns
-            exec_child(in_fd, out_fd, err_fd, program, argv, envp);
+            exec_child(in_fd, out_fd, err_fd, max_fd, program, argv, envp);
         }
 
         return pid;

--- a/execution/src/posix/platform.hpp
+++ b/execution/src/posix/platform.hpp
@@ -5,7 +5,7 @@ namespace leatherman { namespace execution {
 
     std::string format_error(std::string const& message = std::string(), int error = errno);
 
-    pid_t create_child(bool detach, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp);
+    pid_t create_child(leatherman::util::option_set<execution_options> const& options, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp);
 
     void exec_child(int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp);
 

--- a/execution/src/posix/platform.hpp
+++ b/execution/src/posix/platform.hpp
@@ -5,8 +5,11 @@ namespace leatherman { namespace execution {
 
     std::string format_error(std::string const& message = std::string(), int error = errno);
 
-    pid_t create_child(leatherman::util::option_set<execution_options> const& options, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp);
+    pid_t create_child(leatherman::util::option_set<execution_options> const& options,
+                       int in_fd, int out_fd, int err_fd, uint64_t max_fd,
+                       char const* program, char const** argv, char const** envp);
 
-    void exec_child(int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp);
+    void exec_child(int in_fd, int out_fd, int err_fd, uint64_t max_fd,
+                    char const* program, char const** argv, char const** envp);
 
 }}  // namespace leatherman::execution

--- a/execution/src/posix/solaris/platform.cc
+++ b/execution/src/posix/solaris/platform.cc
@@ -155,7 +155,9 @@ namespace leatherman { namespace execution {
         throw execution_exception(format_error(_("failed to abandon contract created for a child process"), err));
     }
 
-    pid_t create_child(leatherman::util::option_set<execution_options> const& options, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    pid_t create_child(leatherman::util::option_set<execution_options> const& options,
+                       int in_fd, int out_fd, int err_fd, uint64_t max_fd,
+                       char const* program, char const** argv, char const** envp)
     {
         bool detach = options[execution_options::create_detached_process];
         // Create a new process contract template & activate it
@@ -177,7 +179,7 @@ namespace leatherman { namespace execution {
                 _exit(err);
             }
             // Exec the child; this never returns
-            exec_child(in_fd, out_fd, err_fd, program, argv, envp);
+            exec_child(in_fd, out_fd, err_fd, max_fd, program, argv, envp);
         }
 
         // This is the parent process

--- a/execution/src/posix/solaris/platform.cc
+++ b/execution/src/posix/solaris/platform.cc
@@ -79,7 +79,7 @@ namespace leatherman { namespace execution {
 
     static int deactivate_contract_template(int tmpl_fd)
     {
-        // WARNING: this function is called from a vfork'd child
+        // WARNING: this function is potentially called from a vfork'd child
         // Do not modify program state from this function; only call setpgid, dup2, close, execve, and _exit
         // Do not allocate heap memory or throw exceptions
         // The child is sharing the address space of the parent process, so carelessly modifying this
@@ -155,15 +155,17 @@ namespace leatherman { namespace execution {
         throw execution_exception(format_error(_("failed to abandon contract created for a child process"), err));
     }
 
-    pid_t create_child(bool detach, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
+    pid_t create_child(leatherman::util::option_set<execution_options> const& options, int in_fd, int out_fd, int err_fd, char const* program, char const** argv, char const** envp)
     {
+        bool detach = options[execution_options::create_detached_process];
         // Create a new process contract template & activate it
         int tmpl_fd = detach ? activate_new_contract_template() : -1;
         int err;
 
         // Fork the child process
-        // Note: this uses vfork, which is inherently unsafe (the parent's address space is shared with the child)
-        pid_t pid = vfork();
+        // Note: this uses vfork (unless the thread_safe execution option is specified), which is inherently unsafe
+        // (the parent's address space is shared with the child)
+        pid_t pid = options[execution_options::thread_safe] ? fork() : vfork();
         if (pid < 0) {
             err = errno;
             deactivate_contract_template(tmpl_fd);


### PR DESCRIPTION
Traditionally leatherman::execution used `vfork()` for the child process creation because of its higher performance and lower virtual memory requirements. But this turned out to be problematic (deadlock prone) in multi-threaded processes on at least Solaris.
So in this PR a new execution option - `thread_safe` - is introduced, which when specified causes leatherman::execution to use slower but safer `fork()` for the child process creation. If the option is not specified the more performant but more dangerous `vfork()` is used to preserve backward compatibility.