### PR TITLE
(LTH-128) Use less Boost.Log magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.11.1]
+
+### Fixed
+- Circumvent a bug in Boost.Log's severity logger that prevented logging on AIX (LTH-128)
+
 ## [0.11.0]
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.11.0)
+project(leatherman VERSION 0.11.1)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.11.0\n"
+"Project-Id-Version: leatherman 0.11.1\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/logging/src/logging.cc
+++ b/logging/src/logging.cc
@@ -12,7 +12,7 @@ using leatherman::locale::_;
 
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/attributes/scoped_attribute.hpp>
-#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/sources/logger.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
 #include <boost/log/sinks/basic_sink_backend.hpp>
@@ -163,13 +163,14 @@ namespace leatherman { namespace logging {
             return;
         }
 
-        src::severity_logger<log_level> slg;
+        src::logger slg;
+        slg.add_attribute("Severity", attrs::constant<log_level>(level));
         slg.add_attribute("Namespace", attrs::constant<string>(logger));
         if (line_num > 0) {
             slg.add_attribute("LineNum", attrs::constant<int>(line_num));
         }
 
-        BOOST_LOG_SEV(slg, level) << message;
+        BOOST_LOG(slg) << message;
     }
 
     istream& operator>>(istream& in, log_level& level)


### PR DESCRIPTION
On AIX, when used with pxp-agent, logging doesn't work because the
log-level (severity) isn't correctly stored by the severity logger. This
is strange as it does work with Facter; I suspect the cause is due to
differences in linking with a .exe (pxp-agent) vs a .so (libfacter)
against libboost_logging.so. Work around the issue in Boost.Log by using
less of its magic, and instead using an explicit attribute for severity.