### PR TITLE
Use GNUInstallDirs to install to /usr/lib/$triplet

### DIFF
--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -1,6 +1,8 @@
 # This file contains utilities used by both leatherman and consuming
 # projects.
 
+include(GNUInstallDirs)
+
 # Save the directory this script is from, to reference other files
 # located in the same directory when using cmake in script mode.
 set(LEATHERMAN_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
@@ -76,8 +78,8 @@ endmacro()
 macro(leatherman_install)
     install(TARGETS ${ARGV}
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib${LIB_SUFFIX}
-        ARCHIVE DESTINATION lib${LIB_SUFFIX})
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     foreach(ARG ${ARGV})
         if (TARGET ${ARG})
             set_target_properties(${ARG} PROPERTIES PREFIX "" IMPORT_PREFIX "")


### PR DESCRIPTION
Debian-based distributions (including Ubuntu) nowadays have their
library directory under /usr/lib/<triplet>, e.g.
/usr/lib/x86_64-linux-gnu/.  /usr/lib64 doesn't exist in Debian.

Use CMake's GNUInstallDirs and CMAKE_INSTALL_LIBDIR to find the libdir
instead of hardcoding lib${LIB_SUFFIX}.

This most likely breaks Windows builds -- and possibly other Linux
builds too; I only have Debian systems in my possession. I hope it's at
least a start for someone more knowledgeable with both other platforms
and CMake to fix :)