### PR TITLE
(LTH-133) Allow using an environment variable to lookup locale files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.11.2]
+
+### Fixed
+- Ability to find locale files with a relocatable package, particularly on Windows (LTH-133)
+
 ## [0.11.1]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,21 +41,28 @@ endif()
 defoption(LEATHERMAN_MOCK_CURL "Use mock curl library for testing Leatherman.curl" ${MOCK_CURL})
 
 add_definitions(${LEATHERMAN_DEFINITIONS})
-add_definitions(-DLEATHERMAN_LOCALE_INSTALL="${CMAKE_INSTALL_PREFIX}/share/locale")
+if (LEATHERMAN_LOCALE_VAR AND LEATHERMAN_LOCALE_INSTALL)
+    # Add an environment variable to look up install prefix at runtime.
+    add_definitions(-DLEATHERMAN_LOCALE_VAR="${LEATHERMAN_LOCALE_VAR}"
+                    -DLEATHERMAN_LOCALE_INSTALL="${LEATHERMAN_LOCALE_INSTALL}")
+else()
+    # Add install location instead.
+    add_definitions(-DLEATHERMAN_LOCALE_INSTALL="${CMAKE_INSTALL_PREFIX}/share/locale")
+endif()
 
 file(GLOB_RECURSE ALL_LEATHERMAN_SOURCES */src/*.cc */inc/*.hpp)
 add_subdirectory(locales)
 
 add_leatherman_dir(catch EXCLUDE_FROM_VARS)
 add_leatherman_dir(nowide)
+add_leatherman_dir(util)
 add_leatherman_dir(locale)
 add_leatherman_dir(logging)
 add_leatherman_dir(rapidjson)
 add_leatherman_dir(json_container)
-add_leatherman_dir(util)
 add_leatherman_dir(file_util)
 add_leatherman_dir(curl)
-if(WIN32)
+if (WIN32)
   add_leatherman_dir(windows)
 endif()
 add_leatherman_dir(dynamic_library)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.11.1)
+project(leatherman VERSION 0.11.2)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(internal)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ add_definitions(${LEATHERMAN_DEFINITIONS})
 add_definitions(-DLEATHERMAN_I18N)
 ```
 
+By default locale files are installed to `${CMAKE_INSTALL_PREFIX}/share/locale`.
+This behavior can be changed to use environment variables for the prefix
+instead by defining `LEATHERMAN_LOCALE_VAR` and `LEATHERMAN_LOCALE_INSTALL`.
+For example, if `LEATHERMAN_LOCALE_VAR=MY_LOCALE_VAR` and
+`LEATHERMAN_LOCALE_INSTALL=../share/locale`, and at runtime `MY_LOCALE_VAR=C:/bin`,
+then Leatherman will search for locale files at `C:/bin/../share/locale`.
+
 #### Extracting and Translating Text
 
 The format strings in logging (the first argument) will automatically be

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -14,6 +14,8 @@ if (LEATHERMAN_USE_LOCALES AND BOOST_STATIC AND APPLE)
     add_leatherman_deps(iconv)
 endif()
 
+leatherman_dependency(util)
+
 add_leatherman_headers(inc/leatherman)
 
 if (LEATHERMAN_USE_LOCALES)

--- a/locale/src/locale.cc
+++ b/locale/src/locale.cc
@@ -1,4 +1,5 @@
 #include <leatherman/locale/locale.hpp>
+#include <leatherman/util/environment.hpp>
 #include <map>
 
 // boost includes are not always warning-clean. Disable warnings that
@@ -26,8 +27,14 @@ namespace leatherman { namespace locale {
         boost::locale::generator gen;
 
         if (!domain.empty()) {
-#ifdef LEATHERMAN_LOCALE_INSTALL
-            // Setup so we can find installed locales.
+            // Setup so we can find installed locales. Expects a default path unless
+            // an environment variable is specified.
+#ifdef LEATHERMAN_LOCALE_VAR
+            string locale_path;
+            if (util::environment::get(LEATHERMAN_LOCALE_VAR, locale_path)) {
+                gen.add_messages_path(locale_path+'/'+LEATHERMAN_LOCALE_INSTALL);
+            }
+#else
             gen.add_messages_path(LEATHERMAN_LOCALE_INSTALL);
 #endif
             for (auto& path : paths) {

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.11.1\n"
+"Project-Id-Version: leatherman 0.11.2\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Allows configuring an environment variable to use at runtime to find
locale files. This environment variable will usually be set by a script
wrapping invocation on Windows.