### PR TITLE
(LTH-134) Add rb_ll2inum binding

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -266,6 +266,10 @@ namespace leatherman {  namespace ruby {
         /**
          * See MRI documentation.
          */
+        VALUE (* const rb_ll2inum)(LONG_LONG);
+        /**
+         * See MRI documentation.
+         */
         VALUE (* const rb_enc_str_new)(char const*, long, rb_encoding_p);
         /**
          * See MRI documentation.

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -65,6 +65,7 @@ namespace leatherman { namespace ruby {
         LOAD_SYMBOL(rb_protect),
         LOAD_SYMBOL(rb_jump_tag),
         LOAD_SYMBOL(rb_int2inum),
+        LOAD_SYMBOL(rb_ll2inum),
         LOAD_SYMBOL(rb_enc_str_new),
         LOAD_SYMBOL(rb_utf8_encoding),
         LOAD_SYMBOL(rb_str_encode),


### PR DESCRIPTION
rb_int2inum usually takes a `long`, which can be 32-bits on some
platforms. rb_ll2inum will always give us a 64-bit value, if it's
available.