### PR TITLE
(LTH-135) Make gettext_compile respect LOCALE env vars

### DIFF
--- a/cmake/leatherman.cmake
+++ b/cmake/leatherman.cmake
@@ -239,6 +239,10 @@ endmacro()
 # Compile gettext .po files into .mo files and configure installing to inst
 # Creates a custom target `translations`.
 #
+# If LEATHERMAN_LOCALE_INSTALL and LEATHERMAN_LOCALE_VAR are set, this will
+# install the newly compiled .mo files to the location specified by these vars.
+# Otherwise, it will use the specified `inst` arg.
+#
 # Does nothing if msgfmt (part of gettext) isn't found. Sets GETTEXT_ENABLED
 # to ON if we can compile .mo files, otherwise sets to OFF. This variable can
 # be used to disable functionality (such as testing) that requires gettext
@@ -273,7 +277,11 @@ macro(gettext_compile dir inst)
                 DEPENDS ${fpath})
             add_custom_target(${lang}-${PROJECT_NAME} DEPENDS ${mo})
             add_dependencies(translations ${lang}-${PROJECT_NAME})
-            install(FILES ${mo} DESTINATION "${inst}/${lang}/LC_MESSAGES")
+            if(LEATHERMAN_LOCALE_VAR AND LEATHERMAN_LOCALE_INSTALL)
+                install(FILES ${mo} DESTINATION "${LEATHERMAN_LOCALE_VAR}/${LEATHERMAN_LOCALE_INSTALL}/${lang}/LC_MESSAGES")
+            else()
+                install(FILES ${mo} DESTINATION "${inst}/${lang}/LC_MESSAGES")
+            endif()
         endforeach()
         set(GETTEXT_ENABLED ON)
     else()


### PR DESCRIPTION
This commit fixes an issue where if the user set LEATHERMAN_LOCALE_VAR
and LEATHERMAN_LOCALE_INSTALL to determine where leatherman should look
for translation files, the install of those files from consuming
projects would not respect those vars and install them in the default
location, which may not correspond to the dir specified with those vars.
Now if the vars are set, leatherman will both install to the specificed
directory and read translations from it at runtime.