### PR TITLE
(LTH-124) Update for Ruby 2.4 unification of Fixnum and Bignum

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -32,7 +32,7 @@ namespace leatherman {  namespace ruby {
     /**
      * Represents a MRI VALUE (a Ruby object).
      * VALUEs can be constants denoting things like true, false, or nil.
-     * They can also be encoded numerical values (Fixnum, for example).
+     * They can also be encoded numerical values (Integer, for example).
      * They can also be pointers to a heap-allocated Ruby object (class, module, etc).
      * The Ruby garbage collector scans the main thread's stack for VALUEs to mark during garbage collection.
      * Therefore, you may encounter "volatile" VALUES. These are marked simply to ensure the compiler
@@ -416,15 +416,11 @@ namespace leatherman {  namespace ruby {
         /**
          * See MRI documentation.
          */
-        VALUE* const rb_cFixnum;
-        /**
-         * See MRI documentation.
-         */
         VALUE* const rb_cFloat;
         /**
          * See MRI documentation.
          */
-        VALUE* const rb_cBignum;
+        VALUE* const rb_cInteger;
 
         /**
          * See MRI documentation.
@@ -596,19 +592,12 @@ namespace leatherman {  namespace ruby {
          */
         bool is_symbol(VALUE value) const;
 
-        /**
-         * Determines if the given value is a fixed number (Fixnum).
-         * @param value The value to check.
-         * @return Returns true if the given value is a fixed number (Fixnum) or false if it is not.
-         */
-        bool is_fixednum(VALUE value) const;
-
          /**
-         * Determines if the given value is a big number (Bignum).
+         * Determines if the given value is an Integer.
          * @param value The value to check.
-         * @return Returns true if the given value is a fixed number (Fixnum) or false if it is not.
+         * @return Returns true if the given value is an integer (Integer) or false if it is not.
          */
-        bool is_bignum(VALUE value) const;
+        bool is_integer(VALUE value) const;
 
         /**
          * Determines if the given value is a float.

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -101,9 +101,8 @@ namespace leatherman { namespace ruby {
         LOAD_SYMBOL(rb_cHash),
         LOAD_SYMBOL(rb_cString),
         LOAD_SYMBOL(rb_cSymbol),
-        LOAD_SYMBOL(rb_cFixnum),
         LOAD_SYMBOL(rb_cFloat),
-        LOAD_SYMBOL(rb_cBignum),
+        LOAD_SYMBOL(rb_cInteger),
         LOAD_SYMBOL(rb_eException),
         LOAD_SYMBOL(rb_eArgError),
         LOAD_SYMBOL(rb_eTypeError),
@@ -395,14 +394,9 @@ namespace leatherman { namespace ruby {
         return is_a(value, *rb_cSymbol);
     }
 
-    bool api::is_fixednum(VALUE value) const
+    bool api::is_integer(VALUE value) const
     {
-        return is_a(value, *rb_cFixnum);
-    }
-
-    bool api::is_bignum(VALUE value) const
-    {
-        return is_a(value, *rb_cBignum);
+        return is_a(value, *rb_cInteger);
     }
 
     bool api::is_float(VALUE value) const

--- a/ruby/tests/api-test.cc
+++ b/ruby/tests/api-test.cc
@@ -48,12 +48,8 @@ TEST_CASE("api::is_*", "[ruby-api]") {
         REQUIRE(ruby.is_float(ruby.eval("1.5")));
         REQUIRE_FALSE(ruby.is_float(ruby.utf8_value("foo")));
 
-        REQUIRE(ruby.is_fixednum(ruby.eval("2")));
-        REQUIRE_FALSE(ruby.is_fixednum(ruby.eval("1.5")));
-
-        REQUIRE(ruby.is_bignum(ruby.eval(to_string(numeric_limits<int64_t>::max()))));
-        REQUIRE_FALSE(ruby.is_bignum(ruby.eval("2")));
-        REQUIRE_FALSE(ruby.is_bignum(ruby.eval("1.5")));
+        REQUIRE(ruby.is_integer(ruby.eval("2")));
+        REQUIRE_FALSE(ruby.is_integer(ruby.eval("1.5")));
     }
 
     SECTION("can correctly identify hashes") {


### PR DESCRIPTION
Ruby 2.4 unified the Fixnum and Bignum types into a single Integer type.
This adjusts Leatherman's Ruby API to take that into account.

NOTE: this will require some updates in Facter, since it is an API breaking change.