### PR TITLE
(packaging) prepare for 0.99.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.99.0]
+This is a pre-release version for Leatherman 1.0.0, containing backwards-incompatible API changes.
+
+### Changed
+- Remove Ruby bindings for Fixnum and Bignum, replace with Integer for Ruby 2.4 support [LTH-124]
+
 ## [0.12.1]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.12.1)
+project(leatherman VERSION 0.99.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${PROJECT_BINARY_DIR}/cmake")
 # Populate locale install location

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.12.1\n"
+"Project-Id-Version: leatherman 0.99.0\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
This is the first in a series of tags representing pre-release
candidates for Leatherman 1.0.0, which contain backwards-incompatible
API changes.