### PR TITLE
(LTH-137) Enable DEP support in Windows version of leatherman binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.2.2)
 project(leatherman VERSION 0.12.1)
 
+if (WIN32)
+    link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${PROJECT_BINARY_DIR}/cmake")
 # Populate locale install location
 configure_file(cmake/leatherman.cmake.in "${PROJECT_BINARY_DIR}/cmake/leatherman.cmake" @ONLY)


### PR DESCRIPTION
Enable nxcompat and dynamicbase flags in Windows builds. Being done
to meet some customer's security audit requirements.