### PR TITLE
(LTH-138) Trim trailing newline when using callbacks

### DIFF
--- a/execution/src/execution.cc
+++ b/execution/src/execution.cc
@@ -443,6 +443,14 @@ namespace leatherman { namespace execution {
         if (trim) {
             boost::trim(stdout_buffer);
             boost::trim(stderr_buffer);
+        } else {
+            // The last output may be just a newline. Trim it so we don't print extra.
+            if (stdout_callback) {
+                boost::trim_if(stdout_buffer, is_any_of("\n\r"));
+            }
+            if (stderr_callback) {
+                boost::trim_if(stderr_buffer, is_any_of("\n\r"));
+            }
         }
         // Log the last line of output for stdout
         if (!stdout_buffer.empty()) {

--- a/execution/tests/fixtures/windows/error_message.bat
+++ b/execution/tests/fixtures/windows/error_message.bat
@@ -1,4 +1,4 @@
 @echo off
-echo error message! >&2
+echo error message!>&2
 echo foo=bar
 exit /b 0

--- a/execution/tests/posix/execution.cc
+++ b/execution/tests/posix/execution.cc
@@ -308,10 +308,10 @@ SCENARIO("executing commands with execution::execute") {
                 REQUIRE_FALSE(success);
             }
         }
-        WHEN("requested to write both stdout and stderr to file") {
+        WHEN("requested to write both stdout and stderr to file without trim") {
             string out_file(spool_dir + "/stdout_test_b.out");
             string err_file(spool_dir + "/stderr_test_b.err");
-            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "", out_file, err_file);
+            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "", out_file, err_file, {}, nullptr, 0, {});
             REQUIRE(boost::filesystem::exists(out_file));
             REQUIRE(boost::filesystem::exists(err_file));
             THEN("stdout and stderr are correctly redirected to different files") {

--- a/execution/tests/windows/execution.cc
+++ b/execution/tests/windows/execution.cc
@@ -187,10 +187,10 @@ SCENARIO("executing commands with execution::execute") {
                 REQUIRE_FALSE(success);
             }
         }
-        WHEN("requested to write both stdout and stderr to file") {
+        WHEN("requested to write both stdout and stderr to file without trim") {
             string out_file(spool_dir + "/stdout_test_b.out");
             string err_file(spool_dir + "/stderr_test_b.err");
-            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat", {}, "", out_file, err_file);
+            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat", {}, "", out_file, err_file, {}, nullptr, 0, {});
             REQUIRE(boost::filesystem::exists(out_file));
             REQUIRE(boost::filesystem::exists(err_file));
             THEN("stdout and stderr are correctly redirected to different files") {


### PR DESCRIPTION
Previously, iterating over lines without the trim option specified, the
last line could be a single newline. The split iterator takes care of
removing those for all but the last line passed to callbacks. Ensure we
trim line breaks for the last line as well.