### PR TITLE
(LTH-139) Allow setting permissions for exec redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0]
+
+### Added
+- Execution with file redirection and `atomic_write_to_file` can specify the permissions of those files. (LTH-139)
+- Leatherman.curl added a download_file function for doing streaming file downloads. (LTH-140)
+
+### Fixed
+- Fix redundant newlines when using `execute` that redirects output to files when not using the `trim` option. This combination now also ensures empty lines are not skipped. A side effect is that when not using `trim`, empty lines may appear when iterating over lines of output via `each_line` as well. (LTH-138)
+
 ## [1.0.0]
 Final tag for Leatherman 1.0.0, containing the same change set as 0.99.0.
 
@@ -9,7 +18,7 @@ Final tag for Leatherman 1.0.0, containing the same change set as 0.99.0.
 This is a pre-release version for Leatherman 1.0.0, containing backwards-incompatible API changes.
 
 ### Changed
-- Remove Ruby bindings for Fixnum and Bignum, replace with Integer for Ruby 2.4 support [LTH-124]
+- Remove Ruby bindings for Fixnum and Bignum, replace with Integer for Ruby 2.4 support (LTH-124)
 
 ## [0.12.1]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 1.0.0)
+project(leatherman VERSION 1.1.0)
 
 if (WIN32)
     link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")

--- a/curl/inc/leatherman/curl/client.hpp
+++ b/curl/inc/leatherman/curl/client.hpp
@@ -8,6 +8,7 @@
 #include "request.hpp"
 #include "response.hpp"
 #include <curl/curl.h>
+#include <boost/optional.hpp>
 #include <boost/filesystem.hpp>
 #include "export.h"
 
@@ -207,10 +208,14 @@ namespace leatherman { namespace curl {
 
         /**
          * Downloads the file from the specified url.
-         * @param req The HTTP request to perform 
-         * @param file_path The file that the downloaded contents will be written to. 
+         * Throws http_file_download_exception if anything goes wrong.
+         * @param req The HTTP request to perform.
+         * @param file_path The file that the downloaded contents will be written to.
+         * @param perms The file permissions to apply when writing to file_path. Ignored on Windows.
          */
-        void download_file(request const& req, std::string const& file_path);
+        void download_file(request const& req,
+                           std::string const& file_path,
+                           boost::optional<boost::filesystem::perms> perms = {});
 
         /**
          * Sets the path to the CA certificate file.
@@ -275,8 +280,6 @@ namespace leatherman { namespace curl {
         LEATHERMAN_CURL_NO_EXPORT void set_client_info(context &ctx);
         LEATHERMAN_CURL_NO_EXPORT void set_ca_info(context& ctx);
         LEATHERMAN_CURL_NO_EXPORT void set_client_protocols(context& ctx);
-
-        LEATHERMAN_CURL_NO_EXPORT void cleanup_temp_file(boost::filesystem::path const& temp_path, FILE* tfp, request const& req, std::string const& file_path, std::string const& reason);
 
         template <typename ParamType>
         LEATHERMAN_CURL_NO_EXPORT void curl_easy_setopt_maybe(

--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -6,6 +6,8 @@
 
 #include <leatherman/util/environment.hpp>
 #include <leatherman/util/option_set.hpp>
+#include <boost/optional.hpp>
+#include <boost/filesystem.hpp>
 
 #include <string>
 #include <vector>
@@ -365,7 +367,7 @@ namespace leatherman { namespace execution {
      * @param environment The environment variables to pass to the child process.
      * @param pid_callback The callback that is called with the pid of the child process. Defaults to no callback, in which case the pid will not be processed.
      * @param timeout The timeout, in seconds. Defaults to no timeout.
-     * @param options The execution options.  Defaults to trimming output and merging the environment.
+     * @param options The execution options. Defaults to trimming output and merging the environment.
      * @return Returns a result struct that will not contain the output of the streams for which a file was specified.
      *
      * Throws an execution_exception error in case it fails to open a file.
@@ -379,6 +381,35 @@ namespace leatherman { namespace execution {
         std::map<std::string, std::string> const& environment = std::map<std::string, std::string>(),
         std::function<void(size_t)> pid_callback = nullptr,
         uint32_t timeout = 0,
+        lth_util::option_set<execution_options> const& options = { execution_options::trim_output, execution_options::merge_environment });
+
+    /**
+     * Executes the given program by writing the output of stdout and stderr to specified files. The output
+     * is processed line-by-line, so binary data isn't supported.
+     * @param file The name or path of the program to execute.
+     * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
+     * @param input A string to place on stdin for the child process before reading output.
+     * @param out_file The file where the output on stdout will be written.
+     * @param err_file The file where the output on stderr will be written.
+     * @param environment The environment variables to pass to the child process.
+     * @param pid_callback The callback that is called with the pid of the child process.
+     * @param timeout The timeout, in seconds.
+     * @param perms The file permissions to apply when creating the out_file and err_file. Ignored on Windows.
+     * @param options The execution options. Defaults to trimming output and merging the environment.
+     * @return Returns a result struct that will not contain the output of the streams for which a file was specified.
+     *
+     * Throws an execution_exception error in case it fails to open a file.
+     */
+    result execute(
+        std::string const& file,
+        std::vector<std::string> const& arguments,
+        std::string const& input,
+        std::string const& out_file,
+        std::string const& err_file,
+        std::map<std::string, std::string> const& environment,
+        std::function<void(size_t)> pid_callback,
+        uint32_t timeout,
+        boost::optional<boost::filesystem::perms> perms,
         lth_util::option_set<execution_options> const& options = { execution_options::trim_output, execution_options::merge_environment });
 
     /**

--- a/execution/src/execution.cc
+++ b/execution/src/execution.cc
@@ -3,6 +3,7 @@
 #include <leatherman/locale/locale.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <cstdlib>
 #include <cstdio>
@@ -15,7 +16,7 @@ using leatherman::locale::_;
 using namespace std;
 using namespace leatherman::logging;
 using namespace leatherman::util;
-using namespace boost::filesystem;
+namespace fs = boost::filesystem;
 using namespace boost::algorithm;
 
 namespace leatherman { namespace execution {
@@ -253,6 +254,21 @@ namespace leatherman { namespace execution {
         uint32_t timeout,
         lth_util::option_set<execution_options> const& options)
     {
+        return execute(file, arguments, input, out_file, err_file, environment, pid_callback, timeout, {}, options);
+    }
+
+    result execute(
+        std::string const& file,
+        std::vector<std::string> const& arguments,
+        std::string const& input,
+        std::string const& out_file,
+        std::string const& err_file,
+        std::map<std::string, std::string> const& environment,
+        std::function<void(size_t)> pid_callback,
+        uint32_t timeout,
+        boost::optional<fs::perms> perms,
+        lth_util::option_set<execution_options> const& options)
+    {
         auto actual_options = options;
         function<bool(string&)> stderr_callback;
         function<bool(string&)> stdout_callback;
@@ -261,7 +277,15 @@ namespace leatherman { namespace execution {
 
         out_stream.open(out_file.c_str(), std::ios::binary);
         if (!out_stream.is_open()) {
-            throw execution_exception(_("failed to open the output file."));
+            throw execution_exception(_("failed to open output file {1}", out_file));
+        }
+
+        boost::system::error_code ec;
+        if (perms) {
+            fs::permissions(out_file, *perms, ec);
+            if (ec) {
+                throw execution_exception(_("failed to modify permissions on output file {1} to {2,num,oct}: {3}", out_file, *perms, ec.message()));
+            }
         }
 
         if (err_file.empty()) {
@@ -269,7 +293,14 @@ namespace leatherman { namespace execution {
         } else {
             err_stream.open(err_file.c_str(), std::ios::binary);
             if (!err_stream.is_open()) {
-                throw execution_exception(_("failed to open the error file."));
+                throw execution_exception(_("failed to open error file {1}", err_file));
+            }
+
+            if (perms) {
+                fs::permissions(err_file, *perms, ec);
+                if (ec) {
+                    throw execution_exception(_("failed to modify permissions on error file {1} to {2,num,oct}: {3}", err_file, *perms, ec.message()));
+                }
             }
 
             stderr_callback = ([&](string& line) {

--- a/execution/tests/posix/execution.cc
+++ b/execution/tests/posix/execution.cc
@@ -19,7 +19,7 @@ using namespace leatherman::logging;
 using namespace leatherman::execution::testing;
 using namespace leatherman::util;
 using namespace leatherman::execution;
-using namespace boost::filesystem;
+namespace fs = boost::filesystem;
 
 SCENARIO("searching for programs with execution::which") {
     GIVEN("an absolute path to an executable file") {
@@ -133,17 +133,17 @@ SCENARIO("executing commands with execution::execute") {
     };
     std::string spool_dir { EXEC_TESTS_DIRECTORY "/spool" };
     auto get_file_content = [spool_dir](string const& filename) {
-        string filepath((path(spool_dir) / filename).string());
+        string filepath((fs::path(spool_dir) / filename).string());
         boost::nowide::ifstream strm(filepath.c_str());
         if (!strm) FAIL("failed to open file: " + filename);
         string content((istreambuf_iterator<char>(strm)), (istreambuf_iterator<char>()));
         strm.close();
         return content;
     };
-    if (!exists(spool_dir) && !create_directories(spool_dir)) {
+    if (!fs::exists(spool_dir) && !fs::create_directories(spool_dir)) {
         FAIL("failed to create spool directory");
     }
-    scope_exit spool_cleaner([spool_dir]() { remove_all(spool_dir); });
+    scope_exit spool_cleaner([spool_dir]() { fs::remove_all(spool_dir); });
     GIVEN("a command that succeeds") {
         THEN("the output should be returned") {
             auto exec = execute("cat", { EXEC_TESTS_DIRECTORY "/fixtures/ls/file3.txt" });
@@ -271,7 +271,7 @@ SCENARIO("executing commands with execution::execute") {
         WHEN("requested to write stdout to file") {
             string out_file(spool_dir + "/stdout_test.out");
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "", out_file);
-            REQUIRE(exists(out_file));
+            REQUIRE(fs::exists(out_file));
             THEN("stdout is correctly redirected to file") {
                 auto output = get_file_content("stdout_test.out");
                 REQUIRE(output == "foo=bar\nsome more stuff\n");
@@ -285,7 +285,7 @@ SCENARIO("executing commands with execution::execute") {
         WHEN("requested to write stdout and stderr to the same file with trim") {
             string out_file(spool_dir + "/stdout_stderr_test.out");
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "", out_file, "", map<string, string>(), nullptr, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_stdout });
-            REQUIRE(boost::filesystem::exists(out_file));
+            REQUIRE(fs::exists(out_file));
             THEN("stdout and stderr are correctly redirected to file") {
                 auto output = get_file_content("stdout_stderr_test.out");
                 REQUIRE(output == "error message!\nfoo=bar\nsome more stuff\n");
@@ -308,12 +308,38 @@ SCENARIO("executing commands with execution::execute") {
                 REQUIRE_FALSE(success);
             }
         }
+        WHEN("requested to write both stdout and stderr to file with permissions") {
+            string out_file(spool_dir + "/stdout_test_b.out");
+            string err_file(spool_dir + "/stderr_test_b.err");
+            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "", out_file, err_file, {}, nullptr, 0,
+                                fs::owner_read | fs::owner_write | fs::group_read, lth_util::option_set<execution_options>{});
+            REQUIRE(fs::exists(out_file));
+            REQUIRE(fs::exists(err_file));
+            THEN("stdout and stderr are correctly redirected to different files") {
+                auto output = get_file_content("stdout_test_b.out");
+                auto error = get_file_content("stderr_test_b.err");
+                REQUIRE(output == "foo=bar\n\nsome more stuff\n");
+                REQUIRE(error == "error message!\n");
+            }
+            THEN("the files have restricted permissions") {
+                auto out_perms = fs::status(out_file).permissions();
+                auto err_perms = fs::status(err_file).permissions();
+                REQUIRE(out_perms == (fs::owner_read | fs::owner_write | fs::group_read));
+                REQUIRE(err_perms == (fs::owner_read | fs::owner_write | fs::group_read));
+            }
+            THEN("the returned results are correct and out/err streams were not buffered") {
+                REQUIRE(exec.success);
+                REQUIRE(exec.output.empty());
+                REQUIRE(exec.error.empty());
+            }
+        }
         WHEN("requested to write both stdout and stderr to file without trim") {
             string out_file(spool_dir + "/stdout_test_b.out");
             string err_file(spool_dir + "/stderr_test_b.err");
-            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "", out_file, err_file, {}, nullptr, 0, {});
-            REQUIRE(boost::filesystem::exists(out_file));
-            REQUIRE(boost::filesystem::exists(err_file));
+            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "",
+                                out_file, err_file, {}, nullptr, 0, lth_util::option_set<execution_options>{});
+            REQUIRE(fs::exists(out_file));
+            REQUIRE(fs::exists(err_file));
             THEN("stdout and stderr are correctly redirected to different files") {
                 auto output = get_file_content("stdout_test_b.out");
                 auto error = get_file_content("stderr_test_b.err");

--- a/execution/tests/windows/execution.cc
+++ b/execution/tests/windows/execution.cc
@@ -190,7 +190,8 @@ SCENARIO("executing commands with execution::execute") {
         WHEN("requested to write both stdout and stderr to file without trim") {
             string out_file(spool_dir + "/stdout_test_b.out");
             string err_file(spool_dir + "/stderr_test_b.err");
-            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat", {}, "", out_file, err_file, {}, nullptr, 0, {});
+            auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat", {}, "",
+                                out_file, err_file, {}, nullptr, 0, lth_util::option_set<execution_options>{});
             REQUIRE(boost::filesystem::exists(out_file));
             REQUIRE(boost::filesystem::exists(err_file));
             THEN("stdout and stderr are correctly redirected to different files") {

--- a/file_util/inc/leatherman/file_util/file.hpp
+++ b/file_util/inc/leatherman/file_util/file.hpp
@@ -4,7 +4,8 @@
  */
 #pragma once
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
 
 #include <string>
 #include <stdexcept>
@@ -55,6 +56,23 @@ namespace leatherman { namespace file_util {
     void atomic_write_to_file(const std::string &text,
                               const std::string &file_path,
                               std::ios_base::openmode mode = std::ios::binary);
+
+    /**
+     * Writes content to a temporary file in the specified mode, then
+     * renames the file to the desired path. If the file already exists,
+     * its previous content will be deleted, so appending is not
+     * possible.
+     * @param text The content to be written
+     * @param file_path The final destination and name of the file
+     * @param perms The file permissions to apply to the file. Ignored on Windows.
+     * @param mode The mode in which to write the file
+     *
+     * Throws an error in case it fails to open the file to write.
+     */
+    void atomic_write_to_file(const std::string &text,
+                              const std::string &file_path,
+                              boost::optional<boost::filesystem::perms> perms,
+                              std::ios_base::openmode mode);
 
     /**
      * Expands a leading tilde to the user's home directory

--- a/file_util/src/file.cc
+++ b/file_util/src/file.cc
@@ -72,6 +72,13 @@ namespace boost_file = boost::filesystem;
     void atomic_write_to_file(const std::string &text,
                               const std::string &file_path,
                               std::ios_base::openmode mode) {
+        atomic_write_to_file(text, file_path, {}, mode);
+    }
+
+    void atomic_write_to_file(const std::string &text,
+                              const std::string &file_path,
+                              boost::optional<boost_file::perms> perms,
+                              std::ios_base::openmode mode) {
         boost::nowide::ofstream ofs;
         std::string tmp_name = file_path + "~";
         ofs.open(tmp_name.c_str(), mode);
@@ -80,6 +87,11 @@ namespace boost_file = boost::filesystem;
                                                         boost_error::make_error_code(
                                                                 boost_error::io_error) };
         }
+
+        if (perms) {
+            boost_file::permissions(tmp_name, *perms);
+        }
+
         ofs << text;
         ofs.close();
         boost_file::rename(tmp_name.data(), file_path.data());

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 1.0.0\n"
+"Project-Id-Version: leatherman 1.1.0\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -34,9 +34,13 @@ msgstr ""
 msgid "Failed to open temporary file for writing"
 msgstr ""
 
+#: curl/src/client.cc
+msgid "Failed to modify permissions of temporary file"
+msgstr ""
+
 #. debug
 #: curl/src/client.cc
-msgid "download completed, now writing result to file"
+msgid "download completed, now writing result to file {1}"
 msgstr ""
 
 #: curl/src/client.cc

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -127,11 +127,19 @@ msgid "executing command: {1}"
 msgstr ""
 
 #: execution/src/execution.cc
-msgid "failed to open the output file."
+msgid "failed to open output file {1}"
 msgstr ""
 
 #: execution/src/execution.cc
-msgid "failed to open the error file."
+msgid "failed to modify permissions on output file {1} to {2,num,oct}: {3}"
+msgstr ""
+
+#: execution/src/execution.cc
+msgid "failed to open error file {1}"
+msgstr ""
+
+#: execution/src/execution.cc
+msgid "failed to modify permissions on error file {1} to {2,num,oct}: {3}"
 msgstr ""
 
 #. debug


### PR DESCRIPTION
Apply file permissions to stdout and stderr files created for the output
of an executed process.