### PR TITLE
(LTH-138) Fix newlines on Windows when redirecting exec

### DIFF
--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -355,7 +355,8 @@ namespace leatherman { namespace execution {
         lth_util::option_set<execution_options> const& options = { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_null });
 
     /**
-     * Executes the given program by writing the output of stdout and stderr to specified files.
+     * Executes the given program by writing the output of stdout and stderr to specified files. The output
+     * is processed line-by-line, so binary data isn't supported.
      * @param file The name or path of the program to execute.
      * @param arguments The arguments to pass to the program. On Windows they will be quoted as needed for spaces.
      * @param input A string to place on stdin for the child process before reading output.

--- a/execution/tests/fixtures/error_message
+++ b/execution/tests/fixtures/error_message
@@ -1,4 +1,5 @@
 #! /usr/bin/env sh
 echo error message! >&2
 echo foo=bar
-
+echo
+echo some more stuff

--- a/execution/tests/fixtures/windows/error_message.bat
+++ b/execution/tests/fixtures/windows/error_message.bat
@@ -1,4 +1,6 @@
 @echo off
 echo error message!>&2
 echo foo=bar
+echo.
+echo some more stuff
 exit /b 0

--- a/execution/tests/posix/execution.cc
+++ b/execution/tests/posix/execution.cc
@@ -274,7 +274,7 @@ SCENARIO("executing commands with execution::execute") {
             REQUIRE(exists(out_file));
             THEN("stdout is correctly redirected to file") {
                 auto output = get_file_content("stdout_test.out");
-                REQUIRE(output == "foo=bar\n");
+                REQUIRE(output == "foo=bar\nsome more stuff\n");
             }
             THEN("the returned results are correct and stdout was not buffered") {
                 REQUIRE(exec.success);
@@ -282,13 +282,13 @@ SCENARIO("executing commands with execution::execute") {
                 REQUIRE(exec.error == "error message!");
             }
         }
-        WHEN("requested to write stdout and stderr to the same file") {
+        WHEN("requested to write stdout and stderr to the same file with trim") {
             string out_file(spool_dir + "/stdout_stderr_test.out");
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message", {}, "", out_file, "", map<string, string>(), nullptr, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_stdout });
             REQUIRE(boost::filesystem::exists(out_file));
             THEN("stdout and stderr are correctly redirected to file") {
                 auto output = get_file_content("stdout_stderr_test.out");
-                REQUIRE(output == "error message!\nfoo=bar\n");
+                REQUIRE(output == "error message!\nfoo=bar\nsome more stuff\n");
             }
             THEN("the returned results are correct and out/err streams were not buffered") {
                 REQUIRE(exec.success);
@@ -317,7 +317,7 @@ SCENARIO("executing commands with execution::execute") {
             THEN("stdout and stderr are correctly redirected to different files") {
                 auto output = get_file_content("stdout_test_b.out");
                 auto error = get_file_content("stderr_test_b.err");
-                REQUIRE(output == "foo=bar\n");
+                REQUIRE(output == "foo=bar\n\nsome more stuff\n");
                 REQUIRE(error == "error message!\n");
             }
             THEN("the returned results are correct and out/err streams were not buffered") {
@@ -427,7 +427,7 @@ SCENARIO("executing commands with execution::execute") {
             log_capture capture(log_level::debug);
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message");
             REQUIRE(exec.success);
-            REQUIRE(exec.output == "foo=bar");
+            REQUIRE(exec.output == "foo=bar\n\nsome more stuff");
             REQUIRE(exec.error.empty());
             THEN("stderr is logged") {
                 auto output = capture.result();
@@ -439,7 +439,7 @@ SCENARIO("executing commands with execution::execute") {
             log_capture capture(log_level::warning);
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/error_message");
             REQUIRE(exec.success);
-            REQUIRE(exec.output == "foo=bar");
+            REQUIRE(exec.output == "foo=bar\n\nsome more stuff");
             REQUIRE(exec.error.empty());
             THEN("stderr is not logged") {
                 auto output = capture.result();

--- a/execution/tests/windows/execution.cc
+++ b/execution/tests/windows/execution.cc
@@ -153,7 +153,7 @@ SCENARIO("executing commands with execution::execute") {
             REQUIRE(exists(out_file));
             THEN("stdout is correctly redirected to file") {
                 auto output = get_file_content("stdout_test.out");
-                REQUIRE(output == "foo=bar\n");
+                REQUIRE(output == "foo=bar\nsome more stuff\n");
             }
             THEN("the returned results are correct and stdout was not buffered") {
                 REQUIRE(exec.success);
@@ -161,13 +161,13 @@ SCENARIO("executing commands with execution::execute") {
                 REQUIRE(exec.error == "error message!");
             }
         }
-        WHEN("requested to write stdout and stderr to the same file") {
+        WHEN("requested to write stdout and stderr to the same file with trim") {
             string out_file(spool_dir + "/stdout_stderr_test.out");
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat", {}, "", out_file, "", {}, nullptr, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_stdout });
             REQUIRE(boost::filesystem::exists(out_file));
             THEN("stdout and stderr are correctly redirected to file") {
                 auto output = get_file_content("stdout_stderr_test.out");
-                REQUIRE(output == "error message!\nfoo=bar\n");
+                REQUIRE(output == "error message!\nfoo=bar\nsome more stuff\n");
             }
             THEN("the returned results are correct and out/err streams were not buffered") {
                 REQUIRE(exec.success);
@@ -196,7 +196,7 @@ SCENARIO("executing commands with execution::execute") {
             THEN("stdout and stderr are correctly redirected to different files") {
                 auto output = get_file_content("stdout_test_b.out");
                 auto error = get_file_content("stderr_test_b.err");
-                REQUIRE(output == "foo=bar\n");
+                REQUIRE(output == "foo=bar\n\nsome more stuff\n");
                 REQUIRE(error == "error message!\n");
             }
             THEN("the returned results are correct and out/err streams were not buffered") {
@@ -210,7 +210,7 @@ SCENARIO("executing commands with execution::execute") {
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat", {}, "", {}, [&pid_from_callback](size_t pid) { pid_from_callback = pid; });
             THEN("the returned results are correct") {
                 REQUIRE(exec.success);
-                REQUIRE(exec.output == "foo=bar");
+                REQUIRE(exec.output == "foo=bar\r\n\r\nsome more stuff");
                 REQUIRE(exec.error.empty());  // stderr is redirected to null
             }
             THEN("the callback is successfully executed") {
@@ -354,7 +354,7 @@ SCENARIO("executing commands with execution::execute") {
             log_capture capture(log_level::debug);
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat");
             REQUIRE(exec.success);
-            REQUIRE(exec.output == "foo=bar");
+            REQUIRE(exec.output == "foo=bar\r\n\r\nsome more stuff");
             REQUIRE(exec.error.empty());
             THEN("stderr is logged") {
                 auto output = capture.result();
@@ -366,7 +366,7 @@ SCENARIO("executing commands with execution::execute") {
             log_capture capture(log_level::warning);
             auto exec = execute(EXEC_TESTS_DIRECTORY "/fixtures/windows/error_message.bat");
             REQUIRE(exec.success);
-            REQUIRE(exec.output == "foo=bar");
+            REQUIRE(exec.output == "foo=bar\r\n\r\nsome more stuff");
             REQUIRE(exec.error.empty());
             THEN("stderr is not logged") {
                 auto output = capture.result();


### PR DESCRIPTION
On Windows, the trailing \r\n of buffered output results in the split
including one of the characters. This is inconvenient behavior from
Boost we need to work around. Fix so that any line that is just \r\n is
skipped when using callbacks.