### PR TITLE
(maint) Update Windows Appveyor CI to use GCC 5.2.0, use myget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1]
+
+### Fixed
+- Generate build artifact with GCC 5.2.0 on Windows.
+
 ## [1.1.0]
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 1.1.0)
+project(leatherman VERSION 1.1.1)
 
 if (WIN32)
     link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,19 @@
 clone_depth: 10
 install:
-  - set
-  - git submodule update --init --recursive
-
-  - choco install -y mingw-w64 -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
+  - choco install -y mingw-w64 -Version 5.2.0 -source https://www.myget.org/F/puppetlabs
   - choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
   - choco install -y gettext -Version 0.19.6 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-toolchain-x64 -Version 2015.12.01.1 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-boost-x64 -Version 1.58.0.2 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
+  - choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
+
   - SET PATH=C:\Ruby21-x64\bin;C:\tools\mingw64\bin;C:\Program Files\gettext-iconv;%PATH%
   - ps: $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
   - ps: $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
 
-  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\boost.7z"
-  - ps: 7z.exe x boost.7z -oC:\tools | FIND /V "ing  "
-
-  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z"
-  - ps: 7z.exe x "curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
-
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCMAKE_PREFIX_PATH="C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DCURL_STATIC=ON -DLEATHERMAN_SHARED="$env:shared" .
+  - ps: cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DBOOST_STATIC=ON -DLEATHERMAN_SHARED="$env:shared" .
   - ps: mingw32-make install
   - ps: 7z.exe a -t7z leatherman.7z C:\tools\leatherman\
 

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 1.1.0\n"
+"Project-Id-Version: leatherman 1.1.1\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Updates Appveyor config to use myget-hosted packages. To use them, we
need to use GCC 5.2.0.