### PR TITLE
(maint) Update docs around boost::filesystem::perms

### DIFF
--- a/curl/inc/leatherman/curl/client.hpp
+++ b/curl/inc/leatherman/curl/client.hpp
@@ -211,7 +211,8 @@ namespace leatherman { namespace curl {
          * Throws http_file_download_exception if anything goes wrong.
          * @param req The HTTP request to perform.
          * @param file_path The file that the downloaded contents will be written to.
-         * @param perms The file permissions to apply when writing to file_path. Ignored on Windows.
+         * @param perms The file permissions to apply when writing to file_path.
+         *              Best avoided on Windows, unexpectedly makes things read-only.
          */
         void download_file(request const& req,
                            std::string const& file_path,

--- a/execution/inc/leatherman/execution/execution.hpp
+++ b/execution/inc/leatherman/execution/execution.hpp
@@ -394,7 +394,8 @@ namespace leatherman { namespace execution {
      * @param environment The environment variables to pass to the child process.
      * @param pid_callback The callback that is called with the pid of the child process.
      * @param timeout The timeout, in seconds.
-     * @param perms The file permissions to apply when creating the out_file and err_file. Ignored on Windows.
+     * @param perms The file permissions to apply when creating the out_file and err_file.
+     *              Best avoided on Windows, unexpectedly makes things read-only.
      * @param options The execution options. Defaults to trimming output and merging the environment.
      * @return Returns a result struct that will not contain the output of the streams for which a file was specified.
      *

--- a/file_util/inc/leatherman/file_util/file.hpp
+++ b/file_util/inc/leatherman/file_util/file.hpp
@@ -64,7 +64,8 @@ namespace leatherman { namespace file_util {
      * possible.
      * @param text The content to be written
      * @param file_path The final destination and name of the file
-     * @param perms The file permissions to apply to the file. Ignored on Windows.
+     * @param perms The file permissions to apply to the file.
+     *              Best avoided on Windows, unexpectedly makes things read-only.
      * @param mode The mode in which to write the file
      *
      * Throws an error in case it fails to open the file to write.


### PR DESCRIPTION
Note that using them is not advised on Windows, as it unexpectedly makes
things read-only. The logic isn't clear at
https://github.com/boostorg/filesystem/blob/boost-1.58.0/src/operations.cpp#L1433-L1453
but I couldn't get a combination of permissions that didn't set
read-only.