### PR TITLE
(LTH-142) Separate file operation errors from server-side errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.2]
+
+### Added
+- Separated the possible failure modes for Leatherman.curl into three categories
+     * Curl setup errors
+     * File operation errors (e.g. writing to disk during file download)
+     * Server side errors (e.g. bad host)
+
+### Changed
+- Simplified the logic of Leatherman.curl's download_file method by abstracting out actions associated with the temporary file (creating, writing, removing) to a class that follows the RAII pattern.
+
 ## [1.1.1]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 1.1.1)
+project(leatherman VERSION 1.1.2)
 
 if (WIN32)
     link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")

--- a/curl/tests/client_test.cc
+++ b/curl/tests/client_test.cc
@@ -15,6 +15,17 @@ using namespace std;
 namespace fs = boost::filesystem;
 namespace nw = boost::nowide;
 
+#define REQUIRE_THROWS_AS_WITH(expression, exception_type, msg_matcher) {\
+    try {\
+        expression;\
+        REQUIRE(false);\
+    } catch (exception_type& e) {\
+        REQUIRE_THAT(e.what(), msg_matcher);\
+    } catch (exception& e) {\
+        REQUIRE(false);\
+    }\
+}
+
 // TODO: Move non-test code to "fixtures.hpp" and "fixtures.cc".
 fs::path find_matching_file(const boost::regex& re) {
     auto file = find_if(
@@ -30,16 +41,9 @@ fs::path find_matching_file(const boost::regex& re) {
     return *file;
 }
 
-void setup_temp_removal_failure() {
-    auto temp_dir_path = find_matching_file(boost::regex(TEMP_DIR_REGEX));
+void remove_temp_file() {
     auto temp_path = find_matching_file(boost::regex(TEMP_FILE_REGEX));
     fs::remove(temp_path);
-    fs::create_directories(temp_path / "fail_file");
-}
-
-void trigger_filesystem_error() {
-    auto temp_dir_path = find_matching_file(boost::regex(TEMP_DIR_REGEX));
-    fs::remove(temp_dir_path.parent_path());
 }
 
 namespace leatherman { namespace curl {
@@ -303,90 +307,90 @@ namespace leatherman { namespace curl {
 
         SECTION("client fails to set HTTP method to POST") {
             test_impl->test_failure_mode = curl_impl::error_mode::http_post_error;
-            REQUIRE_THROWS_AS(test_client.post(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.post(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set HTTP method to PUT") {
             test_impl->test_failure_mode = curl_impl::error_mode::http_put_error;
-            REQUIRE_THROWS_AS(test_client.put(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.put(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the request URL") {
             test_impl->test_failure_mode = curl_impl::error_mode::set_url_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the request headers") {
             test_impl->test_failure_mode = curl_impl::error_mode::set_header_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set cookies in the request") {
             test_impl->test_failure_mode = curl_impl::error_mode::set_cookie_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the header callback function") {
             test_impl->test_failure_mode = curl_impl::error_mode::header_function_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the header write location") {
             test_impl->test_failure_mode = curl_impl::error_mode::header_context_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the body writing callback function") {
             test_impl->test_failure_mode = curl_impl::error_mode::write_body_function_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the body write location") {
             test_impl->test_failure_mode = curl_impl::error_mode::write_body_context_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
         SECTION("client fails to set the read_body callback function") {
             test_impl->test_failure_mode = curl_impl::error_mode::read_body_function_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the read_body data source") {
             test_impl->test_failure_mode = curl_impl::error_mode::read_body_context_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the connection timeout") {
             test_impl->test_failure_mode = curl_impl::error_mode::connect_timeout_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set the request timeout") {
             test_impl->test_failure_mode = curl_impl::error_mode::request_timeout_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set certificate authority info") {
             test_client.set_ca_cert("certfile");
             test_impl->test_failure_mode = curl_impl::error_mode::ca_bundle_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set SSL cert info") {
             test_client.set_client_cert("cert", "key");
             test_impl->test_failure_mode = curl_impl::error_mode::ssl_cert_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to set SSL key info") {
             test_client.set_client_cert("cert", "key");
             test_impl->test_failure_mode = curl_impl::error_mode::ssl_key_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
 
         SECTION("client fails to make http call with https protocol only enabled") {
             test_client.set_supported_protocols(CURLPROTO_HTTPS);
             test_impl->test_failure_mode = curl_impl::error_mode::protocol_error;
-            REQUIRE_THROWS_AS(test_client.get(test_request), http_request_exception);
+            REQUIRE_THROWS_AS(test_client.get(test_request), http_setup_exception);
         }
     }
 
@@ -456,46 +460,56 @@ namespace leatherman { namespace curl {
          CURL* const& handle = test_client.get_handle();
          auto test_impl = reinterpret_cast<curl_impl* const>(handle);
 
-         SECTION("when fopen fails, an http_file_download_exception is thrown") {
+         SECTION("when fopen fails, an http_file_exception is thrown") {
              fs::path parent_dir = temp_dir_path / "parent";
              std::string file_path = (parent_dir / "child").string();
              curl::request req("");
-             REQUIRE_THROWS_WITH(test_client.download_file(req, file_path), "Failed to open temporary file for writing");
+             REQUIRE_THROWS_AS_WITH(
+                 test_client.download_file(req, file_path),
+                 curl::http_file_exception,
+                 Catch::Equals("Failed to open temporary file for writing"));
          }
 
-         SECTION("when curl_easy_setopt fails, an http_file_download_exception is thrown and the temporary file is removed") {
+         SECTION("when curl_easy_setopt fails, an http_setup_exception is thrown and the temporary file is removed") {
              curl::request req("");
              std::string file_path = (temp_dir_path / "file").string();
              test_impl->test_failure_mode = curl_impl::error_mode::set_url_error;
-             REQUIRE_THROWS_AS(test_client.download_file(req, file_path), curl::http_file_download_exception);
+             REQUIRE_THROWS_AS(test_client.download_file(req, file_path), curl::http_setup_exception);
              // Ensure that the temp file was removed
-             REQUIRE_THROWS_AS(find_matching_file(TEMP_FILE_REGEX), std::runtime_error);
+             REQUIRE(fs::is_empty(temp_dir_path));
          }
 
-         SECTION("when a file system error is thrown before the download starts, that error is converted to an http_file_download_exception") {
+         SECTION("when curl_easy_perform fails due to a CURLE_WRITE_ERROR, but the temporary file is removed, an http_file_exception is thrown") {
+             std::string file_path = (temp_dir_path / "file").string();
+             curl::request req("");
+             test_impl->test_failure_mode = curl_impl::error_mode::easy_perform_write_error; 
+             REQUIRE_THROWS_AS_WITH(
+                 test_client.download_file(req, file_path),
+                 curl::http_file_exception,
+                 Catch::StartsWith("Failed to write to the temporary file during download"));
+         }
+
+         SECTION("when curl_easy_perform fails for reasons other than a CURLE_WRITE_ERROR, but the temporary file is removed, only the errbuf message is contained in the thrown http_download_exception") {
              std::string file_path = (temp_dir_path / "file").string();
              curl::request req("");
              test_impl->test_failure_mode = curl_impl::error_mode::easy_perform_error; 
-             test_impl->trigger_external_failure = trigger_filesystem_error;
-             REQUIRE_THROWS_WITH(test_client.download_file(req, file_path), Catch::StartsWith("boost::filesystem"));  
-         }
-
-         SECTION("when curl_easy_perform fails, but the temporary file is removed, only the errbuf message is contained in the thrown http_file_download_exception") {
-             std::string file_path = (temp_dir_path / "file").string();
-             curl::request req("");
-             test_impl->test_failure_mode = curl_impl::error_mode::easy_perform_error; 
-             REQUIRE_THROWS_WITH(test_client.download_file(req, file_path), "easy perform failed"); 
+             REQUIRE_THROWS_AS_WITH(
+                 test_client.download_file(req, file_path),
+                 curl::http_download_exception,
+                 Catch::Equals("easy perform failed")); 
 
              // Ensure that the temp file was removed
-             REQUIRE_THROWS_AS(find_matching_file(TEMP_FILE_REGEX), std::runtime_error);
+             REQUIRE(fs::is_empty(temp_dir_path));
          }
 
-         SECTION("when curl_easy_perform fails and removal of the temporary file fails, then both the errbuf and the failed temporary file removal message are contained in the thrown http_file_download_exception") {
+         SECTION("when renaming the temporary file to the user-provided file path fails, an http_file_exception is thrown") {
              std::string file_path = (temp_dir_path / "file").string();
-             curl::request req("");
-             test_impl->test_failure_mode = curl_impl::error_mode::easy_perform_error; 
-             test_impl->trigger_external_failure = setup_temp_removal_failure;
-             REQUIRE_THROWS_WITH(test_client.download_file(req, file_path), Catch::StartsWith("easy perform failed and failed to remove temporary file file_util_fixture_")); 
+             curl::request req("https://remove_temp_file.com");
+             test_impl->trigger_external_failure = remove_temp_file; 
+             REQUIRE_THROWS_AS_WITH(
+                 test_client.download_file(req, file_path),
+                 curl::http_file_exception,
+                 Catch::StartsWith("Failed to move over the temporary file's downloaded contents")); 
          }
     }
 }}

--- a/curl/tests/mock_curl.hpp
+++ b/curl/tests/mock_curl.hpp
@@ -22,6 +22,7 @@ struct curl_impl
     {
         success,
         easy_perform_error,
+        easy_perform_write_error,
         http_post_error,
         http_put_error,
         set_url_error,

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -17,17 +17,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: curl/inc/leatherman/curl/client.hpp
+msgid "Failed setting up libcurl. Reason: {1}"
+msgstr ""
+
 #: curl/src/client.cc
 msgid "curl_easy_escape failed to escape string."
-msgstr ""
-
-#: curl/src/client.cc
-msgid "failed to create cURL handle."
-msgstr ""
-
-#. debug
-#: curl/src/client.cc
-msgid "request completed (status {1})."
 msgstr ""
 
 #: curl/src/client.cc
@@ -40,11 +35,34 @@ msgstr ""
 
 #. debug
 #: curl/src/client.cc
-msgid "download completed, now writing result to file {1}"
+msgid "Download completed, now writing result to file {1}"
+msgstr ""
+
+#. warning
+#: curl/src/client.cc
+msgid ""
+"Failed to write the results of the temporary file to the actual file {1}"
 msgstr ""
 
 #: curl/src/client.cc
-msgid "{1} and failed to remove temporary file {2}"
+msgid "Failed to move over the temporary file's downloaded contents"
+msgstr ""
+
+#: curl/src/client.cc
+msgid "Failed to properly clean-up the temporary file {1}"
+msgstr ""
+
+#: curl/src/client.cc
+msgid "failed to create cURL handle."
+msgstr ""
+
+#. debug
+#: curl/src/client.cc
+msgid "request completed (status {1})."
+msgstr ""
+
+#: curl/src/client.cc
+msgid "Failed to write to the temporary file during download"
 msgstr ""
 
 #: curl/src/client.cc

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 1.1.1\n"
+"Project-Id-Version: leatherman 1.1.2\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Previously, file operation errors (e.g. setting permissions,
writing to disk) were encapsulated the same way as server-side
errors in a single http_file_download_exception. This commit
creates a new exception for file operation errors,
http_file_operation_exception, to distinguish these cases.