### PR TITLE
(maint) Refactor http_file_operation_exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.3]
+- Refactored Leatherman.curl's http_file_operation_exception to inherit from http_request_exception so that the three possible failure modes are distinguished by class
+
 ## [1.1.2]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 1.1.2)
+project(leatherman VERSION 1.1.3)
 
 if (WIN32)
     link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")

--- a/curl/inc/leatherman/curl/client.hpp
+++ b/curl/inc/leatherman/curl/client.hpp
@@ -209,7 +209,7 @@ namespace leatherman { namespace curl {
     /**
      * The exception for HTTP file download file operation errors.
      */
-    struct LEATHERMAN_CURL_EXPORT http_file_operation_exception : http_file_download_exception
+    struct LEATHERMAN_CURL_EXPORT http_file_operation_exception : http_request_exception
     {
         /**
          * Constructs an http_file_operation_exception.
@@ -229,9 +229,19 @@ namespace leatherman { namespace curl {
          * @param message The exception message.
          */
         http_file_operation_exception(request req, std::string file_path, std::string temp_path, std::string const &message) :
-            http_file_download_exception(req, file_path, message),
+            http_request_exception(req, message),
+            _file_path(file_path),
             _temp_path(std::move(temp_path))
         {
+        }
+
+        /**
+         * Gets the file_path associated with the exception
+         * @return Returns the file_path associated with the exception.
+         */
+        std::string const& file_path() const
+        {
+            return _file_path;
         }
 
         /**
@@ -244,6 +254,7 @@ namespace leatherman { namespace curl {
         }
 
      private:
+        std::string _file_path;
         std::string _temp_path;
     };
 

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 1.1.2\n"
+"Project-Id-Version: leatherman 1.1.3\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
It now inherits from http_request_exception instead of
http_file_download_exception. This makes it explicit in the
exception class which type of error occurred in curl.