### PR TITLE
(maint) Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: precise
 compiler:
   - gcc
 sudo: false


### PR DESCRIPTION
Travis on Trusty includes Ruby 2.4.1. Fixes for that are in later
branches of Leatherman. Fix by pinning to Precise.