### PR TITLE
(maint) Filter warning with Xcode 9

### DIFF
--- a/curl/tests/mock_curl.cc
+++ b/curl/tests/mock_curl.cc
@@ -103,7 +103,10 @@ CURLcode curl_easy_setopt(CURL *handle, CURLoption option, ...)
 {
     auto h = reinterpret_cast<curl_impl*>(handle);
     va_list vl;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvarargs"
     va_start(vl, option);
+#pragma clang diagnostic pop
 
     switch (option) {
         case CURLOPT_HEADERFUNCTION:


### PR DESCRIPTION
Xcode 9 produces a new warning: `passing an object that undergoes
default argument promotion to 'va_start' has undefined behavior`.

The signature needs to match libcurl, so we can't change it. Instead
filter the warning.