### PR TITLE
(maint) Make execution exceptions more specific and drop error logging

### DIFF
--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -223,8 +223,7 @@ namespace leatherman { namespace execution {
             int result = select(max + 1, &read_set, &write_set, nullptr, timeout ? &read_timeout : nullptr);
             if (result == -1) {
                 if (errno != EINTR) {
-                    LOG_ERROR(format_error(_("select call failed")));
-                    throw execution_exception(_("child i/o failed."));
+                    throw execution_exception(format_error(_("select call failed waiting for child i/o")));
                 }
                 // Interrupted by signal
                 LOG_DEBUG("select call was interrupted and will be retried.");
@@ -245,8 +244,7 @@ namespace leatherman { namespace execution {
                     write(pipe.descriptor, pipe.buffer.c_str(), pipe.buffer.size());
                 if (count < 0) {
                     if (errno != EINTR) {
-                        LOG_ERROR("{1} pipe i/o failed: {2}.", pipe.name, format_error());
-                        throw execution_exception(_("child i/o failed."));
+                        throw execution_exception(_("{1} pipe i/o failed: {2}", pipe.name, format_error()));
                     }
                     // Interrupted by signal
                     LOG_DEBUG("{1} pipe i/o was interrupted and will be retried.", pipe.name);
@@ -503,15 +501,13 @@ namespace leatherman { namespace execution {
             struct sigaction sa = {};
             sa.sa_handler = timer_handler;
             if (sigaction(SIGALRM, &sa, nullptr) == -1) {
-                LOG_ERROR(format_error(_("sigaction failed")));
-                throw execution_exception(format_error(_("failed to setup timer")));
+                throw execution_exception(format_error(_("sigaction failed while setting up timeout")));
             }
 
             itimerval timer = {};
             timer.it_value.tv_sec = static_cast<decltype(timer.it_interval.tv_sec)>(timeout);
             if (setitimer(ITIMER_REAL, &timer, nullptr) == -1) {
-                LOG_ERROR(format_error(_("setitimer failed")));
-                throw execution_exception(format_error(_("failed to setup timer")));
+                throw execution_exception(format_error(_("setitimer failed while setting up timeout")));
             }
 
             // Set the resource to disable the timer

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -203,12 +203,7 @@ msgid "{1}: {2} ({3})."
 msgstr ""
 
 #: execution/src/posix/execution.cc
-msgid "select call failed"
-msgstr ""
-
-#: execution/src/posix/execution.cc
-#: execution/src/windows/execution.cc
-msgid "child i/o failed."
+msgid "select call failed waiting for child i/o"
 msgstr ""
 
 #. debug
@@ -216,10 +211,8 @@ msgstr ""
 msgid "select call was interrupted and will be retried."
 msgstr ""
 
-#. error
 #: execution/src/posix/execution.cc
-#: execution/src/windows/execution.cc
-msgid "{1} pipe i/o failed: {2}."
+msgid "{1} pipe i/o failed: {2}"
 msgstr ""
 
 #. debug
@@ -264,15 +257,11 @@ msgid "waitpid failed"
 msgstr ""
 
 #: execution/src/posix/execution.cc
-msgid "sigaction failed"
+msgid "sigaction failed while setting up timeout"
 msgstr ""
 
 #: execution/src/posix/execution.cc
-msgid "failed to setup timer"
-msgstr ""
-
-#: execution/src/posix/execution.cc
-msgid "setitimer failed"
+msgid "setitimer failed while setting up timeout"
 msgstr ""
 
 #. debug
@@ -343,6 +332,15 @@ msgstr ""
 
 #: execution/src/windows/execution.cc
 msgid "failed to create read event."
+msgstr ""
+
+#. error
+#: execution/src/windows/execution.cc
+msgid "{1} pipe i/o failed: {2}."
+msgstr ""
+
+#: execution/src/windows/execution.cc
+msgid "child i/o failed."
 msgstr ""
 
 #. error


### PR DESCRIPTION
Move towards better exceptions rather than logging errors. This removes
redundancy in logging and allows better debugging in pxp-agent when
sending a PXP error response. May help debug PA-1618.