### PR TITLE
(packaging) Prepare for version 0.12.3 [no-promote]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.12.3]
+
+This is a maintenance release to re-sync the code version with the tag, in order to make our internal automation happy
+
+## [0.12.2]
+
+### Added
+- Leatherman can now be built with DEP on Windows
+
 ## [0.12.1]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 0.12.1)
+project(leatherman VERSION 0.12.3)
 
 if (WIN32)
     link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 0.12.1\n"
+"Project-Id-Version: leatherman 0.12.3\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
0.12.2 was tagged without bumping the version number. This is
confusing to our automation, which assumes version files are
authoritative.

Moving forward, leatherman's version file will be managed by this new
automation, so we should not encounter issues like this again.