### PR TITLE
(FACT-1772) Use CMAKE_INSTALL_LIBDIR instead of LIB_SUFFIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.12.4]
+
+- LIB\_SUFFIX has been replaced by CMAKE\_INSTALL\_LIBDIR, which is a default provided by the GNUInstallDirs module (FACT-1772)
+- A new cmake macro, `set_cmake_install_rpath` was added that sets the RPATH for a C++ project that is not being installed to a system library directory
+
 ## [0.12.3]
 
 This is a maintenance release to re-sync the code version with the tag, in order to make our internal automation happy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if (LEATHERMAN_INSTALL)
         cmake/normalize_pot.cmake
         cmake/generate_translations.cmake
     )
-    set(INSTALL_LOC "lib${LIB_SUFFIX}/cmake/leatherman")
+    set(INSTALL_LOC "${CMAKE_INSTALL_LIBDIR}/cmake/leatherman")
     install(FILES
         ${CMAKE_FILES}
         "${PROJECT_BINARY_DIR}/cmake/leatherman.cmake"

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Leatherman is broken up into a number of focused component
 libraries. Both methods of using Leatherman allow you to control which
 components are built and used.
 
-Library install locations can be controlled using the LIB_SUFFIX
-variable, which results in installing libraries to `lib${LIB_SUFFIX}`.
+Library install locations can be controlled using the `CMAKE_INSTALL_LIBDIR`
+variable, which results in installing libraries to `CMAKE_INSTALL_LIBDIR`. It
+will default to a platform-specific directory if its value is not provided
+(e.g. on Fedora 26, this value is lib64).
 
 ### Dependencies
 

--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -209,7 +209,7 @@ macro(add_leatherman_dir dir)
             else()
                 set(COMPONENT_STRING "leatherman_component(${id})")
             endif()
-            install(FILES "${dir}/CMakeLists.txt" DESTINATION "lib${LIB_SUFFIX}/cmake/leatherman" RENAME "${id}.cmake")
+            install(FILES "${dir}/CMakeLists.txt" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/leatherman" RENAME "${id}.cmake")
             set(LEATHERMAN_COMPONENTS "${LEATHERMAN_COMPONENTS}\n${COMPONENT_STRING}")
         endif()
 

--- a/cmake/leatherman.cmake.in
+++ b/cmake/leatherman.cmake.in
@@ -81,8 +81,8 @@ endmacro()
 macro(leatherman_install)
     install(TARGETS ${ARGV}
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib${LIB_SUFFIX}
-        ARCHIVE DESTINATION lib${LIB_SUFFIX})
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     foreach(ARG ${ARGV})
         if (TARGET ${ARG})
             set_target_properties(${ARG} PROPERTIES PREFIX "" IMPORT_PREFIX "")

--- a/cmake/leatherman.cmake.in
+++ b/cmake/leatherman.cmake.in
@@ -367,3 +367,13 @@ macro(unpack_vendored pkg extracted_dir dir)
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src
         )
 endmacro(unpack_vendored)
+
+# Usage: set_cmake_install_rpath
+#
+# Sets RPATH if not installing to a system library directory
+macro(set_cmake_install_rpath)
+  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" INSTALL_IS_SYSTEM_DIR)
+  if ("${INSTALL_IS_SYSTEM_DIR}" STREQUAL "-1")
+      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
+endmacro(set_cmake_install_rpath)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,9 +1,9 @@
 include(leatherman)
+include(GNUInstallDirs)
 defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
 defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
 defoption(CURL_STATIC "Use curl's static libraries" OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON CACHE BOOL "Prepend project includes before system includes")
-set(LIB_SUFFIX "" CACHE STRING "Library install suffix")
 
 # Solaris and AIX have poor support for std::locale and boost::locale
 # with GCC. Don't use them by default.


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR, which is a part of the GNUInstallDirs module,
contains the correct location of the lib directory on the specific
platform that we are building the project so that we (by default)
install to the right lib directories when building our standalone
C++ components.