### PR TITLE
(maint) Use correct flag for verbose test output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ env:
   matrix:
     - TARGET=cpplint
     - TARGET=cppcheck
-    - TARGET="all test install ARGS=-v" DO_RELEASE=true EXTRA_VARS="-DBOOST_STATIC=ON"
-    - TARGET="all test install ARGS=-v" EXTRA_VARS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON" COVERALLS=ON
-    - TARGET="all test install ARGS=-v" EXTRA_VARS="-DLEATHERMAN_SHARED=ON"
-    - TARGET="all test install ARGS=-v" EXTRA_VARS="-DLEATHERMAN_USE_LOCALES=OFF"
-    - TARGET="all test install ARGS=-v" EXTRA_VARS="-DLEATHERMAN_GETTEXT=OFF"
+    - TARGET="all test install ARGS=-V" DO_RELEASE=true EXTRA_VARS="-DBOOST_STATIC=ON"
+    - TARGET="all test install ARGS=-V" EXTRA_VARS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON" COVERALLS=ON
+    - TARGET="all test install ARGS=-V" EXTRA_VARS="-DLEATHERMAN_SHARED=ON"
+    - TARGET="all test install ARGS=-V" EXTRA_VARS="-DLEATHERMAN_USE_LOCALES=OFF"
+    - TARGET="all test install ARGS=-V" EXTRA_VARS="-DLEATHERMAN_GETTEXT=OFF"
 
 deploy:
   provider: releases


### PR DESCRIPTION
Accidentally used `-v` previously instead of `-V`.