### PR TITLE
(LTH-158) Add proxy support to Curl wrapper

### DIFF
--- a/curl/inc/leatherman/curl/client.hpp
+++ b/curl/inc/leatherman/curl/client.hpp
@@ -351,6 +351,13 @@ namespace leatherman { namespace curl {
         void set_client_cert(std::string const& client_cert, std::string const& client_key);
 
         /**
+         * Set proxy information.
+         * @param proxy String with following components [scheme]://[hostname]:[port].
+         *        (see more: https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html)
+         */
+        void set_proxy(std::string const& proxy);
+
+        /**
          * Set and limit what protocols curl will support
          * @param client_protocols bitmask of CURLPROTO_*
          *        (see more: http://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html)
@@ -387,6 +394,7 @@ namespace leatherman { namespace curl {
         std::string _ca_cert;
         std::string _client_cert;
         std::string _client_key;
+        std::string _proxy;
         long _client_protocols = CURLPROTO_ALL;
 
         response perform(http_method method, request const& req);
@@ -407,6 +415,7 @@ namespace leatherman { namespace curl {
         LEATHERMAN_CURL_NO_EXPORT void set_client_info(context &ctx);
         LEATHERMAN_CURL_NO_EXPORT void set_ca_info(context& ctx);
         LEATHERMAN_CURL_NO_EXPORT void set_client_protocols(context& ctx);
+        LEATHERMAN_CURL_NO_EXPORT void set_proxy_info(context& ctx);
 
         template <typename ParamType>
         LEATHERMAN_CURL_NO_EXPORT void curl_easy_setopt_maybe(

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -231,6 +231,7 @@ namespace leatherman { namespace curl {
         set_ca_info(ctx);
         set_client_info(ctx);
         set_client_protocols(ctx);
+        set_proxy_info(ctx);
 
         // Perform the request
         auto result = curl_easy_perform(_handle);
@@ -275,6 +276,7 @@ namespace leatherman { namespace curl {
         set_ca_info(ctx);
         set_client_info(ctx);
         set_client_protocols(ctx);
+        set_proxy_info(ctx);
 
         // More detailed error messages
         curl_easy_setopt_maybe(ctx, CURLOPT_ERRORBUFFER, errbuf);
@@ -303,6 +305,11 @@ namespace leatherman { namespace curl {
     void client::set_ca_cert(string const& cert_file)
     {
         _ca_cert = cert_file;
+    }
+
+    void client::set_proxy(string const& proxy)
+    {
+        _proxy = proxy;
     }
 
     void client::set_client_cert(string const& client_cert, string const& client_key)
@@ -428,6 +435,14 @@ namespace leatherman { namespace curl {
 
         curl_easy_setopt_maybe(ctx, CURLOPT_SSLCERT, _client_cert.c_str());
         curl_easy_setopt_maybe(ctx, CURLOPT_SSLKEY, _client_key.c_str());
+    }
+
+    void client::set_proxy_info(context &ctx) {
+        if (_proxy == "") {
+          return;
+        }
+
+        curl_easy_setopt_maybe(ctx, CURLOPT_PROXY, _proxy.c_str());
     }
 
     void client::set_client_protocols(context& ctx) {

--- a/curl/tests/client_test.cc
+++ b/curl/tests/client_test.cc
@@ -236,6 +236,21 @@ TEST_CASE("curl::client CA bundle and SSL setup") {
         REQUIRE(test_impl->cacert == "cacert");
     }
 
+    SECTION("Proxy should be unspecified by default") {
+        auto resp = test_client.get(test_request);
+        CURL* const& handle = test_client.get_handle();
+        auto test_impl = reinterpret_cast<curl_impl* const>(handle);
+        REQUIRE(test_impl->proxy == "");
+    }
+
+    SECTION("cURL should receive the proxy specified in the request") {
+        test_client.set_proxy("proxy");
+        auto resp = test_client.get(test_request);
+        CURL* const& handle = test_client.get_handle();
+        auto test_impl = reinterpret_cast<curl_impl* const>(handle);
+        REQUIRE(test_impl->proxy == "proxy");
+    }
+
     SECTION("Client cert name should be unspecified by default") {
         auto resp = test_client.get(test_request);
         CURL* const& handle = test_client.get_handle();

--- a/curl/tests/mock_curl.cc
+++ b/curl/tests/mock_curl.cc
@@ -217,6 +217,14 @@ CURLcode curl_easy_setopt(CURL *handle, CURLoption option, ...)
             }
             h->client_cert = va_arg(vl, char*);
             break;
+        case CURLOPT_PROXY:
+            // Set the mock curl proxy to that which was passed in the request.
+            if (h->test_failure_mode == curl_impl::error_mode::proxy_error) {
+                va_end(vl);
+                return CURLE_OUT_OF_MEMORY;
+            }
+            h->proxy = va_arg(vl, char*);
+            break;
         case CURLOPT_SSLKEY:
             // Set the mock curl private keyfile name to that which was passed in the request.
             if (h->test_failure_mode == curl_impl::error_mode::ssl_key_error) {

--- a/curl/tests/mock_curl.hpp
+++ b/curl/tests/mock_curl.hpp
@@ -40,6 +40,7 @@ struct curl_impl
         ssl_cert_error,
         ssl_key_error,
         protocol_error,
+        proxy_error
     };
 
     error_mode test_failure_mode = error_mode::success;
@@ -56,7 +57,7 @@ struct curl_impl
     std::function<size_t(char*, size_t, size_t, void*)> read_function;
     void* read_data; // Where to read the request body from
 
-    std::string request_url, cookie, cacert, client_cert, client_key;
+    std::string request_url, cookie, cacert, client_cert, client_key, proxy;
     long protocols;
     long connect_timeout;
     http_method method = http_method::get;

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 1.4.0\n"
+"Project-Id-Version: leatherman 1.5.0\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Add ability to configure proxy using CULROPT_PROXY.
https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html