### PR TITLE
(PA-2055) Prepare for boost 1.67

### DIFF
--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -70,9 +70,9 @@ endif()
 if (WIN32)
     # Update standard link libraries to explicitly exclude kernel32. It isn't necessary, and when compiling with
     # MinGW makes the executable unusable on Microsoft Nano Server due to including __C_specific_handler.
-    SET(CMAKE_C_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
+    SET(CMAKE_C_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -lbcrypt"
         CACHE STRING "Standard C link libraries." FORCE)
-    SET(CMAKE_CXX_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
+    SET(CMAKE_CXX_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -lbcrypt"
         CACHE STRING "Standard C++ link libraries." FORCE)
 
     # We currently support Windows Vista and later APIs, see

--- a/dynamic_library/CMakeLists.txt
+++ b/dynamic_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS regex)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex system)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS filesystem)
+find_package(Boost 1.54 REQUIRED COMPONENTS filesystem regex system)
 
 add_leatherman_deps(Wbemuuid.lib userenv.lib "${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")


### PR DESCRIPTION
These are the changes I needed to make to successfully build leatherman in puppet-agent with boost 1.67 on Windows (the agent PR is here: https://github.com/puppetlabs/puppet-agent/pull/1482)