### PR TITLE
(PA-2055) Ignore external auto_ptr deprecation warnings

### DIFF
--- a/locale/src/locale.cc
+++ b/locale/src/locale.cc
@@ -5,6 +5,7 @@
 // boost includes are not always warning-clean. Disable warnings that
 // cause problems before including the headers, then re-enable the warnings.
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #include <boost/locale.hpp>
 #pragma GCC diagnostic pop

--- a/util/inc/leatherman/util/strings.hpp
+++ b/util/inc/leatherman/util/strings.hpp
@@ -4,8 +4,11 @@
  */
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/compare.hpp>
+#pragma GCC diagnostic pop
 #include <functional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Boost 1.67's use of std::auto_ptr fails builds with -Werror; This ignores the warnings.

Supports https://github.com/puppetlabs/puppet-agent/pull/1482