### PR TITLE
(maint) Add rb_gv_set to Ruby API bindings

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -210,6 +210,10 @@ namespace leatherman {  namespace ruby {
         /**
          * See MRI documentation.
          */
+        VALUE (* const rb_gv_set)(char const*, VALUE);
+        /**
+         * See MRI documentation.
+         */
         VALUE (* const rb_eval_string)(char const*);
         /**
          * See MRI documentation.

--- a/ruby/src/api.cc
+++ b/ruby/src/api.cc
@@ -51,6 +51,7 @@ namespace leatherman { namespace ruby {
         LOAD_SYMBOL(rb_define_singleton_method),
         LOAD_SYMBOL(rb_class_new_instance),
         LOAD_SYMBOL(rb_gv_get),
+        LOAD_SYMBOL(rb_gv_set),
         LOAD_SYMBOL(rb_eval_string),
         LOAD_SYMBOL(rb_funcall),
         LOAD_ALIASED_SYMBOL(rb_funcallv, rb_funcall2),


### PR DESCRIPTION
We had the getter, but not the setter. The setter is needed in order
to implement FACT-1870