### PR TITLE
(FACT-1872) Add WMI propery for UUID

### DIFF
--- a/windows/inc/leatherman/windows/wmi.hpp
+++ b/windows/inc/leatherman/windows/wmi.hpp
@@ -44,6 +44,11 @@ namespace leatherman { namespace windows {
         constexpr static char const* computersystemproduct = "Win32_ComputerSystemProduct";
 
         /**
+         * Identifier for the WMI property UUID
+         */
+        constexpr static char const* uuid = "UUID";
+
+        /**
          * Identifier for the WMI class Win32_OperatingSystem
          */
         constexpr static char const* operatingsystem = "Win32_OperatingSystem";


### PR DESCRIPTION
As documented from https://docs.microsoft.com/en-us/windows/desktop/CIMWin32Prov/win32-computersystemproduct

I've tested this on an agent build with this PR for facter: https://github.com/puppetlabs/facter/pull/1752

Link to ad-hoc build: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/306/