### PR TITLE
(LTH-160) Fix lengthy closure of open file descriptors

### DIFF
--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -314,9 +314,13 @@ namespace leatherman { namespace execution {
         }
 
         // Close all open file descriptors above stderr
+#if defined(__FreeBSD__)
+        closefrom(STDERR_FILENO + 1);
+#else
         for (uint64_t i = (STDERR_FILENO + 1); i < max_fd; ++i) {
             close(i);
         }
+#endif
 
         // Execute the given program; this should not return if successful
         execve(program, const_cast<char* const*>(argv), const_cast<char* const*>(envp));


### PR DESCRIPTION
Currently leatherman closes each FD after stderr when calling do_exec_child.
On FreeBSD this takes a significant amount of time.
This patch changes the FreeBSD implementation to use the closefrom system call
instead of iterating through all possible FDs.

See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=232538 and @smortex

Co-authored-by: David Blacka <david@blacka.com>