### PR TITLE
(maint) Add option to enable/disable -Werror

### DIFF
--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -2,7 +2,10 @@
 # Each of our project dirs sets CMAKE_CXX_FLAGS based on these. We do
 # not set CMAKE_CXX_FLAGS globally because gtest is not warning-clean.
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "\\w*Clang")
-    set(LEATHERMAN_CXX_FLAGS "-std=c++11 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-tautological-constant-out-of-range-compare ${CMAKE_CXX_FLAGS}")
+    if (ENABLE_CXX_WERROR)
+        set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
+    endif()
+    set(LEATHERMAN_CXX_FLAGS "-std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-tautological-constant-out-of-range-compare ${CMAKE_CXX_FLAGS}")
 
     # Clang warns that 'register' is deprecated; 'register' is used throughout boost, so it can't be an error yet.
     # The warning flag is different on different clang versions so we need to extract the clang version.
@@ -40,8 +43,12 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # it's also sometimes wrong
     set(CMAKE_CXX_FLAGS "-Wno-maybe-uninitialized ${CMAKE_CXX_FLAGS}")
 
+    if (ENABLE_CXX_WERROR)
+        set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
+    endif()
+
     # missing-field-initializers is disabled because GCC can't make up their mind how to treat C++11 initializers
-    set(LEATHERMAN_CXX_FLAGS "-std=c++11 -Wall -Werror -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-unknown-pragmas -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS}")
+    set(LEATHERMAN_CXX_FLAGS "-std=c++11 -Wall -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-unknown-pragmas -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS}")
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
         set(LEATHERMAN_CXX_FLAGS "-Wextra ${LEATHERMAN_CXX_FLAGS}")
     endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,4 +1,5 @@
 include(leatherman)
+defoption(ENABLE_CXX_WERROR "Enables the -Werror compiler option" ON)
 defoption(COVERALLS "Generate code coverage using Coveralls.io" OFF)
 defoption(BOOST_STATIC "Use Boost's static libraries" OFF)
 defoption(CURL_STATIC "Use curl's static libraries" OFF)


### PR DESCRIPTION
GCC 8.2 outputs far more warnings than previous GCC versions. Thus, to
avoid blocking dev. work on these warnings, this commit adds the
ENABLE_CXX_WERROR option that disables -Werror by default, but still
gives people the option to enable it for e.g. local development.