### PR TITLE
(LTH-160) Use closefrom(2) when available

### DIFF
--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -63,3 +63,8 @@ if (BUILDING_LEATHERMAN)
         "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp"
     )
 endif()
+
+check_library_exists(c closefrom /lib CLOSEFROM_IN_LIBC)
+if ("${CLOSEFROM_IN_LIBC}" STREQUAL "1")
+    add_compile_definitions(HAS_CLOSEFROM)
+endif()

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -314,7 +314,7 @@ namespace leatherman { namespace execution {
         }
 
         // Close all open file descriptors above stderr
-#if defined(__FreeBSD__)
+#ifdef HAS_CLOSEFROM
         closefrom(STDERR_FILENO + 1);
 #else
         for (uint64_t i = (STDERR_FILENO + 1); i < max_fd; ++i) {

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -314,9 +314,13 @@ namespace leatherman { namespace execution {
         }
 
         // Close all open file descriptors above stderr
+#if defined(__FreeBSD__)
+        closefrom(STDERR_FILENO + 1);
+#else
         for (uint64_t i = (STDERR_FILENO + 1); i < max_fd; ++i) {
             close(i);
         }
+#endif
 
         // Execute the given program; this should not return if successful
         execve(program, const_cast<char* const*>(argv), const_cast<char* const*>(envp));


### PR DESCRIPTION
This is a follow-up to #286 by @nwitkowski and @dblacka (I have no permission to push in nwitkowski's repo but have the expected code locally).

I added a commit checking for `closeform(2)` in the CMake configuration and using the new macro instead of checking for the os name.