### PR TITLE
(maint) Use add_definitions instead of add_compile_definitions

### DIFF
--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -66,5 +66,5 @@ endif()
 
 check_library_exists(c closefrom /lib CLOSEFROM_IN_LIBC)
 if ("${CLOSEFROM_IN_LIBC}" STREQUAL "1")
-    add_compile_definitions(HAS_CLOSEFROM)
+    add_definitions(-DHAS_CLOSEFROM)
 endif()


### PR DESCRIPTION
`add_compile_defintions` is a relatively new cmake feature; This uses
`add_definitions` in execution's CMakeLists.txt instead for
compatibility with older versions of CMake.