### PR TITLE
(LTH-163) Call ruby_sysinit to initialize Windows sockets

### DIFF
--- a/ruby/inc/leatherman/ruby/api.hpp
+++ b/ruby/inc/leatherman/ruby/api.hpp
@@ -709,6 +709,7 @@ namespace leatherman {  namespace ruby {
         // Imported Ruby functions that should not be called externally
         int (* const ruby_setup)();
         void (* const ruby_init)();
+        void (* const ruby_sysinit)(int*, char***);
         void* (* const ruby_options)(int, char**);
         int (* const ruby_cleanup)(volatile int);
 


### PR DESCRIPTION
Ruby >= 2.5 has changed how the Windows sockets are started (see: ruby/ruby@e33b1690), requiring a call to `rb_w32_sysinit` for starting them.

Not having this call causes segmentation faults when querying custom facts that use Windows Sockets with Ruby versions 2.5 and higher.