### PR TITLE
(FACT-1919) Add environment::get_int to get environment variables as integers

### DIFF
--- a/util/inc/leatherman/util/environment.hpp
+++ b/util/inc/leatherman/util/environment.hpp
@@ -16,6 +16,14 @@ namespace leatherman { namespace util {
     struct environment
     {
         /**
+         * Gets an environment variable as integer.
+         * @param name The name of the environment variable to get.
+         * @param default_value The value to return if the variable is absent or invalid.
+         * @return Returns the environment variable if present and valid or the default value if not.
+         */
+        static int get_int(std::string const& name, int default_value);
+
+        /**
          * Gets an environment variable.
          * @param name The name of the environment variable to get.
          * @param value Returns the value of the environment variable.

--- a/util/src/environment.cc
+++ b/util/src/environment.cc
@@ -5,6 +5,18 @@ using namespace std;
 
 namespace leatherman { namespace util {
 
+    int environment::get_int(string const& name, int default_value)
+    {
+        auto variable = boost::nowide::getenv(name.c_str());
+
+        try {
+            return stoi(variable);
+        }
+        catch (...) {
+            return default_value;
+        }
+    }
+
     bool environment::get(string const& name, string& value)
     {
         auto variable = boost::nowide::getenv(name.c_str());

--- a/util/tests/environment.cc
+++ b/util/tests/environment.cc
@@ -15,7 +15,37 @@ SCENARIO("getting an environment variable") {
     boost::nowide::unsetenv("ENVTEST");
     value = "";
     REQUIRE_FALSE(environment::get("ENVTEST", value));
+    REQUIRE(environment::get_int("ENVTEST", 100) == 100);
     REQUIRE(value.empty());
+}
+
+SCENARIO("getting an int environment variable") {
+    boost::nowide::setenv("INTVAR", "100", 1);
+    boost::nowide::setenv("STRVAR", "BAR", 1);
+    boost::nowide::setenv("EMPTYVAR", "", 1);
+    GIVEN("an int variable") {
+        THEN("should return the converted value as int") {
+            REQUIRE(environment::get_int("INTVAR", 1) == 100);
+        }
+        boost::nowide::unsetenv("INTVAR");
+    }
+    GIVEN("a string variable") {
+        THEN("should return the default value") {
+            REQUIRE(environment::get_int("STRVAR", 123) == 123);
+        }
+        boost::nowide::unsetenv("STRVAR");
+    }
+    GIVEN("an empty variable") {
+        THEN("should return the default value") {
+            REQUIRE(environment::get_int("EMPTYVAR", 123) == 123);
+        }
+        boost::nowide::unsetenv("EMPTYVAR");
+    }
+    GIVEN("a non-existent variable") {
+        THEN("should return the default value") {
+            REQUIRE(environment::get_int("NOVAR", 123) == 123);
+        }
+    }
 }
 
 SCENARIO("setting an environment variable") {


### PR DESCRIPTION
Add a new helper function to simplify getting integer environment variables from the system.

The function parameters are the environment variable name, and the default value to return. If the environment variable to get does not exist, or cannot be cleanly coverted to an integer, the default value is returned instead.

Example usage:
```cpp
static const unsigned int EC2_SESSION_TIMEOUT = environment::get_int("EC2_SESSION_TIMEOUT", 5000);
```