### PR TITLE
(LTH-162) Use /proc where available to close open file descriptors

### DIFF
--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -66,5 +66,10 @@ endif()
 
 check_library_exists(c closefrom /lib CLOSEFROM_IN_LIBC)
 if ("${CLOSEFROM_IN_LIBC}" STREQUAL "1")
-    add_compile_definitions(HAS_CLOSEFROM)
+    add_definitions(-DHAS_CLOSEFROM)
+endif()
+
+if (IS_DIRECTORY "/proc/self/fd")
+    add_definitions(-DHAS_PROC_PID)
+    message("-- Found /proc")
 endif()

--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -63,3 +63,8 @@ if (BUILDING_LEATHERMAN)
         "${CMAKE_CURRENT_LIST_DIR}/tests/fixtures.hpp"
     )
 endif()
+
+check_library_exists(c closefrom /lib CLOSEFROM_IN_LIBC)
+if ("${CLOSEFROM_IN_LIBC}" STREQUAL "1")
+    add_compile_definitions(HAS_CLOSEFROM)
+endif()

--- a/execution/CMakeLists.txt
+++ b/execution/CMakeLists.txt
@@ -68,8 +68,3 @@ check_library_exists(c closefrom /lib CLOSEFROM_IN_LIBC)
 if ("${CLOSEFROM_IN_LIBC}" STREQUAL "1")
     add_definitions(-DHAS_CLOSEFROM)
 endif()
-
-if (IS_DIRECTORY "/proc/self/fd")
-    add_definitions(-DHAS_PROC_PID)
-    message("-- Found /proc")
-endif()

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -314,10 +314,9 @@ namespace leatherman { namespace execution {
         }
 
         // Close all open file descriptors above stderr
-#if defined(HAS_CLOSEFROM)
+#ifdef HAS_CLOSEFROM
         closefrom(STDERR_FILENO + 1);
 #else
-  #if defined(HAS_PROC_PID)
         uint64_t fd;
         const char* fdpath = "/proc/self/fd";
         std::list<uint64_t> fd_list;
@@ -332,10 +331,10 @@ namespace leatherman { namespace execution {
             for (auto fd : fd_list) {
                 close(fd);
             }
-        } else  //NOLINT
-  #endif  // HAS_PROC_PID
-        for (uint64_t i = (STDERR_FILENO + 1); i < max_fd; ++i) {
-            close(i);
+        } else {
+            for (uint64_t i = (STDERR_FILENO + 1); i < max_fd; ++i) {
+                close(i);
+            }
         }
 #endif  // HAS_CLOSEFROM
 

--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -314,9 +314,13 @@ namespace leatherman { namespace execution {
         }
 
         // Close all open file descriptors above stderr
+#ifdef HAS_CLOSEFROM
+        closefrom(STDERR_FILENO + 1);
+#else
         for (uint64_t i = (STDERR_FILENO + 1); i < max_fd; ++i) {
             close(i);
         }
+#endif
 
         // Execute the given program; this should not return if successful
         execve(program, const_cast<char* const*>(argv), const_cast<char* const*>(envp));


### PR DESCRIPTION
On systems where `/proc` is available, use `/proc/self/fd` to close only open file descriptors.
Without this change, facter would iterate over the max open file descriptor range and runs would take a long time.

```
$ ulimit -n 1024000
$ ./bin/facter --no-cache
Before: 1024000 - 9s
After:  1024000 - 0,2s
```

Also backports https://github.com/puppetlabs/leatherman/pull/291.