### PR TITLE
(maint) Fix boost::nowide::getenv on OS X

### DIFF
--- a/util/src/environment.cc
+++ b/util/src/environment.cc
@@ -8,11 +8,14 @@ namespace leatherman { namespace util {
     int environment::get_int(string const& name, int default_value)
     {
         auto variable = boost::nowide::getenv(name.c_str());
+        if (!variable) {
+            return default_value;
+        }
 
         try {
             return stoi(variable);
         }
-        catch (...) {
+        catch (invalid_argument&) {
             return default_value;
         }
     }


### PR DESCRIPTION
Environment tests segfault on OS X due to an uncaught exception. Return early from get_int if the variable we're trying to get does not exist.

Fixes an OS X test issue introduced by https://github.com/puppetlabs/leatherman/pull/301.