### PR TITLE
(LTH-166) Check if waitpid was merely interrupted

### DIFF
--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -503,9 +503,14 @@ namespace leatherman { namespace execution {
                 kill(-child, SIGKILL);
             }
             // Wait for the child to exit
-            if (waitpid(child, &status, 0) == -1) {
-                LOG_DEBUG(format_error(_("waitpid failed")));
-                return;
+            while (waitpid(child, &status, 0) == -1) {
+                if ( errno == EINTR ) {
+                    LOG_DEBUG(format_error(_("waitpid was interrupted by a signal, retrying")));
+                    continue;
+                } else {
+                    LOG_DEBUG(format_error(_("waitpid failed")));
+                    return;
+                }
             }
             if (WIFEXITED(status)) {
                 status = static_cast<char>(WEXITSTATUS(status));


### PR DESCRIPTION
A signal may interrupt a system call such as waitpid, in which case it would return -1 but with errno set to EINTR. The typical solution is to run waitpid inside a while loop and continue looping while waitpid returns -1 with the errno variable is set to EINTR. This patch does exactly that.

This patch fixes this particularly nasty bug: https://tickets.puppetlabs.com/browse/FACT-2019, but one could easily imagine other strange bugs (or rather, Heisenbugs!!!) occurring as a result.