### PR TITLE
cmake: explicit boost components discovery (required for boost 1.71)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Boost "1.54" REQUIRED COMPONENTS system date_time chrono log log_setup thread filesystem regex locale)
+
 include_directories(BEFORE ${LEATHERMAN_CATCH_INCLUDE} ${LEATHERMAN_INCLUDE_DIRS})
 add_executable(leatherman_test main.cc ${LEATHERMAN_TEST_SRCS})
 


### PR DESCRIPTION
Currently using boost 1.71 compiling the test executable results in
cmake errors for not using find_package for the required boost
components for proper discovery.