### PR TITLE
(LTH-168) Get DWORD values from Windows Registry

### DIFF
--- a/windows/inc/leatherman/windows/registry.hpp
+++ b/windows/inc/leatherman/windows/registry.hpp
@@ -43,6 +43,15 @@ namespace leatherman { namespace windows {
         std::string get_registry_string(HKEY hkey, std::string const& subkey, std::string const& value);
 
         /**
+         * Retrieve a DWORD value from the registry.
+         * @param hkey The registry key handle.
+         * @param subkey The name of the registry key.
+         * @param value The name of the registry value.
+         * @return A integer value corresponding to a REG_DWORD type.
+         */
+        unsigned long get_registry_dword(HKEY hkey, std::string const& subkey, std::string const& value);
+
+        /**
          * Retrieve a vector of string values from the registry.
          * @param hkey The registry key handle.
          * @param subkey The name of the registry key.


### PR DESCRIPTION
This commit extends the private `get_regvalue` function to also resolve DWORD values from the registry.

For external usage, the `get_registry_dword` function is added, which behaves similar to `get_registry_string` but works on DWORDs and returns an unsigned long value.

Getting the value as DWORD, converting to wstring, then converting again to unsigned long is redundant but I didn't want to write another function for this specific functionality.

There seem to be no tests for this part of Leatherman.