### PR TITLE
(packaging) Bump to version '1.10.0' [no-promote]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 1.9.0)
+project(leatherman VERSION 1.10.0)
 
 if (WIN32)
     link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")


### PR DESCRIPTION
1.9.0 was released without running the pipeline, so a manual bump to next version is needed.