### PR TITLE
(PUP-10166) adapt to openssl-1.1.1/boost-1.67

### DIFF
--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -77,9 +77,9 @@ endif()
 if (WIN32)
     # Update standard link libraries to explicitly exclude kernel32. It isn't necessary, and when compiling with
     # MinGW makes the executable unusable on Microsoft Nano Server due to including __C_specific_handler.
-    SET(CMAKE_C_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
+    SET(CMAKE_C_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -lbcrypt"
         CACHE STRING "Standard C link libraries." FORCE)
-    SET(CMAKE_CXX_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
+    SET(CMAKE_CXX_STANDARD_LIBRARIES "-luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -lbcrypt"
         CACHE STRING "Standard C++ link libraries." FORCE)
 
     # We currently support Windows Vista and later APIs, see

--- a/dynamic_library/CMakeLists.txt
+++ b/dynamic_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS regex)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex system)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")

--- a/locale/src/locale.cc
+++ b/locale/src/locale.cc
@@ -5,6 +5,7 @@
 // boost includes are not always warning-clean. Disable warnings that
 // cause problems before including the headers, then re-enable the warnings.
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #include <boost/locale.hpp>
 #pragma GCC diagnostic pop

--- a/util/inc/leatherman/util/strings.hpp
+++ b/util/inc/leatherman/util/strings.hpp
@@ -4,8 +4,11 @@
  */
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/compare.hpp>
+#pragma GCC diagnostic pop
 #include <functional>
 #include <string>
 #include <vector>

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS filesystem)
+find_package(Boost 1.54 REQUIRED COMPONENTS filesystem regex system)
 
 add_leatherman_deps(Wbemuuid.lib userenv.lib "${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")


### PR DESCRIPTION
cherry-pick commits needed to compile with openssl-1.1.1/boost-1.67