### PR TITLE
Include header for std::invalid_argument

### DIFF
--- a/util/src/environment.cc
+++ b/util/src/environment.cc
@@ -1,5 +1,6 @@
 #include <leatherman/util/environment.hpp>
 #include <boost/nowide/cenv.hpp>
+#include <stdexcept>
 
 using namespace std;
 


### PR DESCRIPTION
As documented at https://gcc.gnu.org/gcc-10/porting_to.html#cxx the C++ headers in GCC 10 no longer include `<stdexcept>` in places that don't need it. This causes leatherman to fail to compile because it uses `std::invalid_argument` without including the right header.