### PR TITLE
(LTH-170) Increase builtin check buffer size

### DIFF
--- a/execution/src/posix/execution.cc
+++ b/execution/src/posix/execution.cc
@@ -145,7 +145,7 @@ namespace leatherman { namespace execution {
         string data;
         string cmd = "type ";
         cmd.append(file);
-        const int buffer_offset = 25;
+        const int buffer_offset = 128;
         const int max_buffer = buffer_offset + file.length();
         char buffer[max_buffer];
         FILE *stream = popen(cmd.c_str(), "r");


### PR DESCRIPTION
On some systems/kernels, `type builtin` could return `. is a special shell builtin` instead of `. is a shell builtin` which went over our hardcoded buffer size.

Increase the buffer size to also support this case.