### PR TITLE
(maint) Address warning to build with Clang 12.0.0 on macOS

### DIFF
--- a/json_container/src/json_container.cc
+++ b/json_container/src/json_container.cc
@@ -620,7 +620,7 @@ namespace leatherman { namespace json_container {
     void JsonContainer::setValue<>(json_value& jval, std::vector<bool> new_value ) {
         jval.SetArray();
 
-        for (const auto& value : new_value) {
+        for (auto value : new_value) {
             json_value tmp_val;
             tmp_val.SetBool(value);
             jval.PushBack(tmp_val, document_root_->GetAllocator());


### PR DESCRIPTION
Addresses a new warning in Clang 12
```
../json_container/src/json_container.cc:623:26: error: loop variable 'value' is always a copy because the range of type 'std::vector<bool>' does not return a reference [-Werror,-Wrange-loop-analysis]
        for (const auto& value : new_value) {
                         ^
```

I also had to set `-Wno-unknown-warning-option` in `CMAKE_CXX_FLAGS` to avoid an unknown warning in the latest version of Boost.