### PR TITLE
(PA-3474) Add CMake option to configure dynamicbase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 3.2.2)
 project(leatherman VERSION 1.12.4)
 
+option(DYNAMICBASE "Add dynamicbase linker option" ON)
 if (WIN32)
-    link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")
+    if (DYNAMICBASE)
+        link_libraries("-Wl,--nxcompat -Wl,--dynamicbase")
+    else()
+        link_libraries("-Wl,--nxcompat")
+    endif()
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${PROJECT_BINARY_DIR}/cmake")


### PR DESCRIPTION
OpenSSL in FIPS mode expects `LIBEAY32.dll` to always be loaded at the
same memory address. If the library is relocated for any reason, any
attempts to use it (either as a library or through `openssl.exe`) would
fail and print gibberish on the screen.

As Leatherman is always built with dynamicbase on, there's a small
chance that a Leatherman library gets allocated an address that clashes
with `LIBEAY32.dll` (0x63000000), causing the library to relocate and
fail the FIPS start up check.

By disabling dynamicbase, we ensure that the Leatherman libraries are
always using their base addresses, which are less likely to conflict
with `LIBEAY32.dll`.

This commit adds a DYNAMICBASE CMake option which configures this flag.

Similar work was done for facter in https://github.com/puppetlabs/facter/pull/1873,
and pxp-agent in https://github.com/puppetlabs/pxp-agent/pull/781.