### PR TITLE
(packaging) Bump to version '1.12.10' [no-promote]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(leatherman VERSION 1.12.9)
+project(leatherman VERSION 1.12.10)
 
 option(DYNAMICBASE "Add dynamicbase linker option" ON)
 if (WIN32)


### PR DESCRIPTION
User error during release meant that these version bumps were never added; manually adding here.