### PR TITLE
(PE-36763) Migrate CURLOPT_PROTOCOLS{,_STR}

### DIFF
--- a/cmake/cflags.cmake
+++ b/cmake/cflags.cmake
@@ -3,7 +3,7 @@
 # not set CMAKE_CXX_FLAGS globally because gtest is not warning-clean.
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "\\w*Clang")
     if (ENABLE_CXX_WERROR)
-        set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     endif()
     set(LEATHERMAN_CXX_FLAGS "-std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-tautological-constant-out-of-range-compare ${CMAKE_CXX_FLAGS}")
 

--- a/curl/inc/leatherman/curl/client.hpp
+++ b/curl/inc/leatherman/curl/client.hpp
@@ -369,7 +369,7 @@ namespace leatherman { namespace curl {
          * @param client_protocols bitmask of CURLPROTO_*
          *        (see more: http://curl.haxx.se/libcurl/c/CURLOPT_PROTOCOLS.html)
          */
-        void set_supported_protocols(long client_protocols);
+        void set_supported_protocols(std::string client_protocols);
 
      private:
         client(client const&) = delete;
@@ -403,7 +403,7 @@ namespace leatherman { namespace curl {
         std::string _client_key;
         std::string _client_crl;
         std::string _proxy;
-        long _client_protocols = CURLPROTO_ALL;
+        std::string _client_protocols = "ALL"; // see https://curl.se/libcurl/c/CURLOPT_PROTOCOLS_STR.html
 
         response perform(http_method method, request const& req);
         void download_file_helper(request const& req,

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -50,7 +50,6 @@ namespace leatherman { namespace curl {
         if (init_helper.result() != CURLE_OK) {
             throw http_exception(curl_easy_strerror(init_helper.result()));
         }
-
         _resource = curl_easy_init();
     }
 
@@ -325,7 +324,7 @@ namespace leatherman { namespace curl {
         _client_key = client_key;
     }
 
-    void client::set_supported_protocols(long client_protocols) {
+    void client::set_supported_protocols(string client_protocols) {
         _client_protocols = client_protocols;
     }
 
@@ -472,7 +471,7 @@ namespace leatherman { namespace curl {
     }
 
     void client::set_client_protocols(context& ctx) {
-        curl_easy_setopt_maybe(ctx, CURLOPT_PROTOCOLS, _client_protocols);
+        curl_easy_setopt_maybe(ctx, CURLOPT_PROTOCOLS_STR, _client_protocols.c_str());
     }
 
     size_t client::read_body(char* buffer, size_t size, size_t count, void* ptr)

--- a/curl/tests/client_test.cc
+++ b/curl/tests/client_test.cc
@@ -297,18 +297,18 @@ TEST_CASE("curl::client CA bundle and SSL setup") {
     }
 
     SECTION("cURL should make an HTTP request with the specified HTTP protocol") {
-        test_client.set_supported_protocols(CURLPROTO_HTTP);
+        test_client.set_supported_protocols("HTTP");
         auto resp = test_client.get(test_request);
         CURL* const& handle = test_client.get_handle();
         auto test_impl = reinterpret_cast<curl_impl* const>(handle);
-        REQUIRE(test_impl->protocols == CURLPROTO_HTTP);
+        REQUIRE(test_impl->protocols == "HTTP");
     }
 
     SECTION("cURL defaults to all protocols if no protocols are specified") {
         auto resp = test_client.get(test_request);
         CURL* const& handle = test_client.get_handle();
         auto test_impl = reinterpret_cast<curl_impl* const>(handle);
-        REQUIRE(test_impl->protocols == CURLPROTO_ALL);
+        REQUIRE(test_impl->protocols == "ALL");
     }
 }
 
@@ -418,7 +418,7 @@ TEST_CASE("curl::client errors") {
     }
 
     SECTION("client fails to make http call with https protocol only enabled") {
-        test_client.set_supported_protocols(CURLPROTO_HTTPS);
+        test_client.set_supported_protocols("HTTPS");
         test_impl->test_failure_mode = curl_impl::error_mode::protocol_error;
         REQUIRE_THROWS_AS(test_client.get(test_request), http_curl_setup_exception);
     }
@@ -428,8 +428,9 @@ TEST_CASE("curl::client errors") {
         mock_client test_client;
         temp_directory temp_dir;
         fs::path temp_dir_path = fs::path(temp_dir.get_dir_name()); 
+        // TEMP: handle is a LEATHERMAN_CURL_EXPORT
         CURL* const& handle = test_client.get_handle();
-        auto test_impl = reinterpret_cast<curl_impl* const>(handle);
+        curl_impl* test_impl = reinterpret_cast<curl_impl* const>(handle);
         std::string url = "https://download.com";
 
         SECTION("when a response is not passed in") {
@@ -440,7 +441,7 @@ TEST_CASE("curl::client errors") {
 
                 test_client.set_ca_cert(ca_file);
                 test_client.set_client_cert(cert_file, key_file);
-                test_client.set_supported_protocols(CURLPROTO_HTTPS);
+                test_client.set_supported_protocols("HTTPS");
 
                 std::string file_path = (temp_dir_path / "test_file").string();
                 std::string token = "token";
@@ -455,7 +456,7 @@ TEST_CASE("curl::client errors") {
                 REQUIRE(test_impl->cacert == ca_file);
                 REQUIRE(test_impl->client_cert == cert_file);
                 REQUIRE(test_impl->client_key == key_file);
-                REQUIRE(test_impl->protocols == CURLPROTO_HTTPS);
+                REQUIRE(test_impl->protocols == "HTTPS");
                 REQUIRE(test_impl->connect_timeout == connect_timeout);
                 REQUIRE(std::string(test_impl->header->data) == ("X-Authentication: " + token));
                 if (test_impl->header->next) {
@@ -507,7 +508,7 @@ TEST_CASE("curl::client errors") {
 
               test_client.set_ca_cert(ca_file);
               test_client.set_client_cert(cert_file, key_file);
-              test_client.set_supported_protocols(CURLPROTO_HTTPS);
+              test_client.set_supported_protocols("HTTPS");
 
               std::string file_path = (temp_dir_path / "test_file").string();
               std::string token = "token";
@@ -523,7 +524,7 @@ TEST_CASE("curl::client errors") {
               REQUIRE(test_impl->cacert == ca_file);
               REQUIRE(test_impl->client_cert == cert_file);
               REQUIRE(test_impl->client_key == key_file);
-              REQUIRE(test_impl->protocols == CURLPROTO_HTTPS);
+              REQUIRE(test_impl->protocols == "HTTPS");
               REQUIRE(test_impl->connect_timeout == connect_timeout);
               REQUIRE(std::string(test_impl->header->data) == ("X-Authentication: " + token));
               if (test_impl->header->next) {

--- a/curl/tests/mock_curl.cc
+++ b/curl/tests/mock_curl.cc
@@ -254,12 +254,12 @@ CURLcode curl_easy_setopt(CURL *handle, CURLoption option, ...)
                 return CURLE_COULDNT_CONNECT;
             }
             break;
-        case CURLOPT_PROTOCOLS:
+        case CURLOPT_PROTOCOLS_STR:
             if (h->test_failure_mode == curl_impl::error_mode::protocol_error) {
                 va_end(vl);
                 return CURLE_COULDNT_CONNECT;
             }
-            h->protocols = va_arg(vl, long);
+            h->protocols = va_arg(vl, char*);
             break;
         case CURLOPT_ERRORBUFFER:
             h->errbuf = va_arg(vl, char*); 

--- a/curl/tests/mock_curl.hpp
+++ b/curl/tests/mock_curl.hpp
@@ -59,7 +59,6 @@ struct curl_impl
     void* read_data; // Where to read the request body from
 
     std::string request_url, cookie, cacert, client_cert, client_key, client_crl, proxy;
-    long protocols;
     long connect_timeout;
     http_method method = http_method::get;
 
@@ -67,6 +66,7 @@ struct curl_impl
 
     std::string read_buffer; // Buffer to test reading the request body
     std::string resp_body;   // Response body which should be written to a context using the write_body function callback
+    std::string protocols;  // Protocols (see CURLOPT_PROTOCOLS_STR)
 
     char* errbuf = 0;
     // Pointer to trigger failure callbacks

--- a/locales/leatherman.pot
+++ b/locales/leatherman.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: leatherman 1.12.4\n"
+"Project-Id-Version: leatherman 1.12.12\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -18,6 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: curl/inc/leatherman/curl/client.hpp
+#, c++-format
 msgid "Failed setting up libcurl. Reason: {1}"
 msgstr ""
 
@@ -26,6 +27,7 @@ msgid "curl_easy_escape failed to escape string."
 msgstr ""
 
 #: curl/src/client.cc
+#, c++-format
 msgid "File operation error: {1}"
 msgstr ""
 
@@ -39,11 +41,13 @@ msgstr ""
 
 #. debug
 #: curl/src/client.cc
+#, c++-format
 msgid "Download completed, now writing result to file {1}"
 msgstr ""
 
 #. warning
 #: curl/src/client.cc
+#, c++-format
 msgid ""
 "Failed to write the results of the temporary file to the actual file {1}"
 msgstr ""
@@ -69,6 +73,7 @@ msgstr ""
 
 #. warning
 #: curl/src/client.cc
+#, c++-format
 msgid "Failed to properly clean-up the temporary file {1}"
 msgstr ""
 
@@ -78,6 +83,7 @@ msgstr ""
 
 #. debug
 #: curl/src/client.cc
+#, c++-format
 msgid "request completed (status {1})."
 msgstr ""
 
@@ -86,6 +92,7 @@ msgid "failed to write to the temporary file during download"
 msgstr ""
 
 #: curl/src/client.cc
+#, c++-format
 msgid "File download server side error: {1}"
 msgstr ""
 
@@ -95,71 +102,84 @@ msgstr ""
 
 #. debug
 #: curl/src/client.cc
+#, c++-format
 msgid "requesting {1}."
 msgstr ""
 
 #. warning
 #: curl/src/client.cc
+#, c++-format
 msgid "unexpected HTTP response header: {1}."
 msgstr ""
 
 #. debug
 #: dynamic_library/src/posix/dynamic_library.cc
+#, c++-format
 msgid "library {1} not found {2} ({3})."
 msgstr ""
 
 #. debug
 #: dynamic_library/src/posix/dynamic_library.cc
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "library {1} is not loaded when attempting to load symbol {2}."
 msgstr ""
 
 #. debug
 #: dynamic_library/src/posix/dynamic_library.cc
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "symbol {1} not found in library {2}, trying alias {3}."
 msgstr ""
 
 #: dynamic_library/src/posix/dynamic_library.cc
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "symbol {1} was not found in {2}."
 msgstr ""
 
 #. debug
 #: dynamic_library/src/posix/dynamic_library.cc
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "symbol {1} not found in library {2}."
 msgstr ""
 
 #. debug
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid ""
 "library matching pattern {1} not found, CreateToolhelp32Snapshot failed: {2}."
 msgstr ""
 
 #. debug
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "library matching pattern {1} not found, Module32First failed: {2}."
 msgstr ""
 
 #. debug
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "library {1} found from pattern {2}"
 msgstr ""
 
 #. debug
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid ""
 "library {1} found from pattern {2}, but unloaded before handle was acquired"
 msgstr ""
 
 #. debug
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "no loaded libraries found matching pattern {1}"
 msgstr ""
 
 #. debug
 #: dynamic_library/src/windows/dynamic_library.cc
+#, c++-format
 msgid "library {1} not found {2}."
 msgstr ""
 
@@ -169,10 +189,12 @@ msgstr ""
 
 #. debug
 #: execution/src/execution.cc
+#, c++-format
 msgid "executing command: {1}"
 msgstr ""
 
 #: execution/src/execution.cc
+#, c++-format
 msgid "failed to open output file {1}"
 msgstr ""
 
@@ -181,6 +203,7 @@ msgid "failed to modify permissions on output file {1} to {2,num,oct}: {3}"
 msgstr ""
 
 #: execution/src/execution.cc
+#, c++-format
 msgid "failed to open error file {1}"
 msgstr ""
 
@@ -193,11 +216,14 @@ msgstr ""
 msgid "completed processing output: closing child pipes."
 msgstr ""
 
-#: execution/src/posix/execution.cc windows/src/system_error.cc
+#: execution/src/posix/execution.cc
+#: windows/src/system_error.cc
+#, c++-format
 msgid "{1} ({2})"
 msgstr ""
 
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "{1}: {2} ({3})."
 msgstr ""
 
@@ -212,32 +238,41 @@ msgstr ""
 
 #. debug
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "{1} pipe i/o was closed early, process may have ignored input."
 msgstr ""
 
 #. debug
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "{1} pipe i/o was interrupted and will be retried."
 msgstr ""
 
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "{1} pipe i/o failed: {2}"
 msgstr ""
 
-#: execution/src/posix/execution.cc execution/src/windows/execution.cc
+#: execution/src/posix/execution.cc
+#: execution/src/windows/execution.cc
+#, c++-format
 msgid "command timed out after {1} seconds."
 msgstr ""
 
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "{1}={2}"
 msgstr ""
 
 #. debug
-#: execution/src/posix/execution.cc execution/src/windows/execution.cc
+#: execution/src/posix/execution.cc
+#: execution/src/windows/execution.cc
+#, c++-format
 msgid "{1} was not found on the PATH."
 msgstr ""
 
-#: execution/src/posix/execution.cc execution/src/windows/execution.cc
+#: execution/src/posix/execution.cc
+#: execution/src/windows/execution.cc
 msgid "child process returned non-zero exit status."
 msgstr ""
 
@@ -271,19 +306,23 @@ msgstr ""
 
 #. debug
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "process was signaled with signal {1}."
 msgstr ""
 
 #. debug
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "process exited with status code {1}."
 msgstr ""
 
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "child process returned non-zero exit status ({1})."
 msgstr ""
 
 #: execution/src/posix/execution.cc
+#, c++-format
 msgid "child process was terminated by signal ({1})."
 msgstr ""
 
@@ -314,11 +353,13 @@ msgid "Unsupported argument on Windows expand with value false"
 msgstr ""
 
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "\\\\.\\Pipe\\leatherman.{1}.{2}.{3}.{4}"
 msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to create read pipe: {1}."
 msgstr ""
 
@@ -328,6 +369,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to create write pipe: {1}."
 msgstr ""
 
@@ -337,6 +379,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to create {1} read event: {2}."
 msgstr ""
 
@@ -346,6 +389,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "{1} pipe i/o failed: {2}."
 msgstr ""
 
@@ -355,6 +399,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to wait for child process i/o: {1}."
 msgstr ""
 
@@ -364,6 +409,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "asynchronous i/o on {1} failed: {2}."
 msgstr ""
 
@@ -377,6 +423,7 @@ msgstr ""
 
 #. debug
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "child environment {1}={2}"
 msgstr ""
 
@@ -390,6 +437,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to create process: {1}."
 msgstr ""
 
@@ -399,6 +447,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to create job object: {1}."
 msgstr ""
 
@@ -408,6 +457,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to associate process with job object: {1}."
 msgstr ""
 
@@ -417,16 +467,19 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to terminate process: {1}."
 msgstr ""
 
 #. warning
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "could not terminate process {1} because a job object could not be used."
 msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to create waitable timer: {1}."
 msgstr ""
 
@@ -436,6 +489,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to set waitable timer: {1}."
 msgstr ""
 
@@ -445,6 +499,7 @@ msgstr ""
 
 #. error
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "failed to wait for child process to terminate: {1}."
 msgstr ""
 
@@ -458,6 +513,7 @@ msgstr ""
 
 #. debug
 #: execution/src/windows/execution.cc
+#, c++-format
 msgid "process exited with exit code {1}."
 msgstr ""
 
@@ -468,15 +524,18 @@ msgstr ""
 
 #. debug
 #: file_util/src/file.cc
+#, c++-format
 msgid "Error reading file: {1}"
 msgstr ""
 
 #: file_util/src/file.cc
+#, c++-format
 msgid "failed to open {1}"
 msgstr ""
 
 #. warning
 #: file_util/src/file.cc
+#, c++-format
 msgid "{1} has not been set"
 msgstr ""
 
@@ -498,6 +557,7 @@ msgid "invalid json"
 msgstr ""
 
 #: json_container/src/json_container.cc
+#, c++-format
 msgid "unknown object entry with key: {1}"
 msgstr ""
 
@@ -526,12 +586,14 @@ msgid "not a double"
 msgstr ""
 
 #: logging/src/logging.cc
+#, c++-format
 msgid ""
 "invalid log level '{1}': expected none, trace, debug, info, warn, error, or "
 "fatal."
 msgstr ""
 
 #: logging/src/posix/logging.cc
+#, c++-format
 msgid "invalid syslog facility: '{1}'"
 msgstr ""
 
@@ -546,6 +608,7 @@ msgstr ""
 
 #. info
 #: ruby/src/api.cc
+#, c++-format
 msgid "ruby loaded from \"{1}\"."
 msgstr ""
 
@@ -556,24 +619,29 @@ msgstr ""
 
 #. info
 #: ruby/src/api.cc
+#, c++-format
 msgid "using ruby version {1}"
 msgstr ""
 
 #: ruby/src/api.cc
+#, c++-format
 msgid "size_t maximum exceeded, requested size was {1}"
 msgstr ""
 
 #: ruby/src/api.cc
+#, c++-format
 msgid "maximum array size exceeded, reported size was {1}"
 msgstr ""
 
 #. warning
 #: ruby/src/api.cc
+#, c++-format
 msgid "preferred ruby library \"{1}\" could not be loaded."
 msgstr ""
 
 #. warning
 #: ruby/src/api.cc
+#, c++-format
 msgid "ruby library \"{1}\" could not be loaded."
 msgstr ""
 
@@ -584,32 +652,39 @@ msgstr ""
 
 #. debug
 #: ruby/src/api.cc
+#, c++-format
 msgid "ruby was found at \"{1}\"."
 msgstr ""
 
 #. warning
 #: ruby/src/api.cc
+#, c++-format
 msgid "ruby failed to run: {1}"
 msgstr ""
 
 #. debug
 #: ruby/src/api.cc
+#, c++-format
 msgid ""
 "ruby library \"{1}\" was not found: ensure ruby was built with the --enable-"
 "shared configuration option."
 msgstr ""
 
 #: windows/src/file_util.cc
+#, c++-format
 msgid "error finding FOLDERID_ProgramData: {1}"
 msgstr ""
 
 #. debug
-#: windows/src/process.cc windows/src/user.cc
+#: windows/src/process.cc
+#: windows/src/user.cc
+#, c++-format
 msgid "OpenProcessToken call failed: {1}"
 msgstr ""
 
 #. debug
 #: windows/src/process.cc
+#, c++-format
 msgid "GetTokenInformation call failed: {1}"
 msgstr ""
 
@@ -618,15 +693,18 @@ msgid "invalid HKEY specified"
 msgstr ""
 
 #: windows/src/registry.cc
+#, c++-format
 msgid "error reading registry key {1} {2}: {3}"
 msgstr ""
 
 #: windows/src/system_error.cc
+#, c++-format
 msgid "unknown error ({1})"
 msgstr ""
 
 #. debug
 #: windows/src/user.cc
+#, c++-format
 msgid "Failed to create administrators SID: {1}"
 msgstr ""
 
@@ -637,6 +715,7 @@ msgstr ""
 
 #. debug
 #: windows/src/user.cc
+#, c++-format
 msgid "Failed to check membership: {1}"
 msgstr ""
 
@@ -647,6 +726,7 @@ msgstr ""
 
 #. debug
 #: windows/src/user.cc
+#, c++-format
 msgid "GetUserProfileDirectoryW call failed: {1}"
 msgstr ""
 
@@ -692,32 +772,38 @@ msgstr ""
 
 #. debug
 #: windows/src/wmi.cc
+#, c++-format
 msgid "ignoring {1}-dimensional array in query {2}.{3}"
 msgstr ""
 
 #. debug
 #: windows/src/wmi.cc
+#, c++-format
 msgid ""
 "WMI query {1}.{2} result could not be converted from type {3} to a string"
 msgstr ""
 
 #. debug
 #: windows/src/wmi.cc
+#, c++-format
 msgid "query {1} failed"
 msgstr ""
 
 #. debug
 #: windows/src/wmi.cc
+#, c++-format
 msgid "query {1}.{2} could not be found"
 msgstr ""
 
 #. debug
 #: windows/src/wmi.cc
+#, c++-format
 msgid "only single value requested from array for key {1}"
 msgstr ""
 
 #. debug
 #: windows/src/wmi.cc
+#, c++-format
 msgid "only single entry requested from array of entries for key {1}"
 msgstr ""
 


### PR DESCRIPTION
This PR removes the [deprecated `CURLOPT_PROTOCOLS` option](https://curl.se/libcurl/c/CURLOPT_PROTOCOLS.html) and replaces it with the new [`CURLOPT_PROTOCOLS_STR` option](https://curl.se/libcurl/c/CURLOPT_PROTOCOLS_STR.html).

Jira: https://perforce.atlassian.net/browse/PE-36763

# Testing
This builds and the unit tests all pass

DO NOT MERGE UNTIL: all consumers of leatherman (pxp-agent, etc.) have been updated to use this option.
