### PR TITLE
(PE-37481) Open file with SH_DENYNO sharing mode

### DIFF
--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -142,6 +142,7 @@ namespace leatherman { namespace curl {
         close_fp();
         boost::system::error_code ec;
         fs::rename(_temp_path, _file_path, ec);
+        LOG_DEBUG("fs::rename {1}, {2}, error_code: {3}", _temp_path, _file_path, ec);
         if (ec) {
             LOG_WARNING("Failed to write the results of the temporary file to the actual file {1}", _file_path);
             throw http_file_operation_exception(_req, _file_path, make_file_err_msg(_("failed to move over the temporary file's downloaded contents")));

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -10,6 +10,11 @@
 #include <boost/nowide/fstream.hpp>
 #include <sstream>
 
+#ifdef _WIN32
+#include <stdio.h>
+#include <share.h>
+#endif
+
 // Mark string for translation (alias for leatherman::locale::format)
 using leatherman::locale::_;
 
@@ -101,6 +106,9 @@ namespace leatherman { namespace curl {
     {
         try {
             _temp_path = fs::path(file_path).parent_path() / fs::unique_path("temp_file_%%%%-%%%%-%%%%-%%%%");
+            #ifdef _WIN32
+            _fp = _fsopen(_temp_path.string().c_str(), "w+", _SH_DENYNO);
+            #else
             _fp = boost::nowide::fopen(_temp_path.string().c_str(), "wb");
             if (!_fp) {
                 throw http_file_operation_exception(_req, _file_path, make_file_err_msg(_("failed to open temporary file for writing")));

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -107,7 +107,7 @@ namespace leatherman { namespace curl {
         try {
             _temp_path = fs::path(file_path).parent_path() / fs::unique_path("temp_file_%%%%-%%%%-%%%%-%%%%");
             #ifdef _WIN32
-            _fp = _fsopen(_temp_path.string().c_str(), "w+", _SH_DENYNO);
+            _fp = _fsopen(_temp_path.string().c_str(), "wb", _SH_DENYNO);
             #else
             _fp = boost::nowide::fopen(_temp_path.string().c_str(), "wb");
             #endif

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -110,6 +110,7 @@ namespace leatherman { namespace curl {
             _fp = _fsopen(_temp_path.string().c_str(), "w+", _SH_DENYNO);
             #else
             _fp = boost::nowide::fopen(_temp_path.string().c_str(), "wb");
+            #endif
             if (!_fp) {
                 throw http_file_operation_exception(_req, _file_path, make_file_err_msg(_("failed to open temporary file for writing")));
             }


### PR DESCRIPTION
On Windows, use the `_fsopen` function with the `_SH_DENYNO` sharing mode to allow multiple threads to access the same file.

# NOTE: I am also looking into using the [`CreateFileW`](https://github.com/boostorg/filesystem/issues/305) method mentioned in that issue.

# Testing
I built this branch and ran it as a puppet-agent, and it resolved the error in the ticket, you can see all these tasks succeeded
![image](https://github.com/puppetlabs/leatherman/assets/261552/004ebdf2-7f71-4df7-a318-a11d75959b20)
