### PR TITLE
(maint) Remove -DLEATHERMAN_SHARED=OFF test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 clone_depth: 10
 environment:
   matrix:
-  - shared: OFF
   - shared: ON
 
 init:


### PR DESCRIPTION
Everything we use leatherman to build with uses -DLEATHERMAN_SHARED=true (linking to it as a shared library), so we don't need to test that cmake flag.

New changes ended up breaking for the mock_curl used for testing with that flag on, and we simply don't have the priority to fix it. So just remove that test