### PR TITLE
(PE-37481) Add retry with exponential backoff when error 32 (file in use on windows) occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Sample Library CMakeLists.txt file](#sample-library-cmakeliststxt-file)
   - [Vendoring Other Libraries](#vendoring-other-libraries)
 - [How To Release](#how-to-release)
+- [How To Run Tests](#how-to-run-tests)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -414,3 +415,16 @@ the `nowide` and `catch` CMake files are both solid examples.
 [1]: https://github.com/philsquared/Catch
 [2]: https://github.com/miloyip/rapidjson
 [3]: json_container/README.md
+
+## How to run tests
+
+To run the leatherman tests, you need `cmake` and a C++ compiler.
+
+```
+# at the root of the leatherman/ directory
+mkdir build
+cd build
+cmake ..
+make leatherman_test
+bin/leatherman_test
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - SET PATH=C:\Ruby21-x64\bin;C:\tools\mingw64\bin;C:\Program Files\gettext-iconv;%PATH%
 
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DBOOST_STATIC=ON -DLEATHERMAN_SHARED="$env:shared" .
+  - ps: cmake -G "MinGW Makefiles" -DENABLE_CXX_WERROR=OFF -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DCMAKE_INSTALL_PREFIX=C:\tools\leatherman -DBOOST_STATIC=ON -DLEATHERMAN_SHARED="$env:shared" .
   - ps: mingw32-make -j2
 
 test_script:

--- a/curl/CMakeLists.txt
+++ b/curl/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS regex system chrono filesystem)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex system filesystem thread)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")

--- a/curl/CMakeLists.txt
+++ b/curl/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS regex system filesystem)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex system chrono filesystem)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")

--- a/curl/CMakeLists.txt
+++ b/curl/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost 1.54 REQUIRED COMPONENTS regex system filesystem thread)
+find_package(Boost 1.54 REQUIRED COMPONENTS regex chrono system filesystem thread)
 
 add_leatherman_deps("${Boost_LIBRARIES}")
 add_leatherman_includes("${Boost_INCLUDE_DIRS}")

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -137,7 +137,7 @@ namespace leatherman { namespace curl {
     }
 
     bool error_file_in_use(const boost::system::error_code& ec) {
-        bool same = (ec == boost::system::error_code(32, boost::system::system_category()));
+        bool same = (ec.value() == 32);
         LOG_DEBUG("error_file_in_use({1}), same = {2}", ec, same);
         return same;
     }
@@ -153,7 +153,7 @@ namespace leatherman { namespace curl {
             fs::rename(_temp_path, _file_path, ec);
             wait_millis *= 2;
             max_retries -= 1;
-        } while (max_retries > 0 && error_file_in_use(ec));
+        } while (error_file_in_use(ec) && max_retries > 0);
     }
 
 
@@ -162,6 +162,7 @@ namespace leatherman { namespace curl {
         close_fp();
         boost::system::error_code ec;
         fs::rename(_temp_path, _file_path, ec);
+        LOG_DEBUG("error_code = {1}", ec);
         if (error_file_in_use(ec)) {
             write_retry_with_exp_backoff(_temp_path, _file_path);
         }

--- a/curl/src/client.cc
+++ b/curl/src/client.cc
@@ -162,7 +162,7 @@ namespace leatherman { namespace curl {
         close_fp();
         boost::system::error_code ec;
         fs::rename(_temp_path, _file_path, ec);
-        if(error_file_in_use(ec)) {
+        if (error_file_in_use(ec)) {
             write_retry_with_exp_backoff(_temp_path, _file_path);
         }
 


### PR DESCRIPTION
This PR adds:

- Instructions for running the tests
- A retry loop with exponential backoff (100ms up to 5 times, doubling each time) when there's a system error 32
    - This is to avoid having to make windows-specific code
